### PR TITLE
WIP Seq: a new abstraction for dealing with pure transformations

### DIFF
--- a/lib/lwd/dune
+++ b/lib/lwd/dune
@@ -1,7 +1,7 @@
 (library 
   (name lwd) 
   (public_name lwd)
-  (modules lwd lwd_table lwd_infix lwd_utils) 
+  (modules lwd lwd_seq lwd_table lwd_infix lwd_utils) 
   (libraries seq)
   (inline_tests (backend qtest.lib))
   (wrapped false))

--- a/lib/lwd/lwd.ml
+++ b/lib/lwd/lwd.ml
@@ -330,9 +330,10 @@ let rec sub_release
           if revidx < count then (
             let obj = tn.entries.(count) in
             tn.entries.(revidx) <- obj;
+            tn.entries.(count) <- dummy;
             mov_idx self count revidx obj
-          );
-          tn.entries.(count) <- dummy;
+          ) else
+            tn.entries.(revidx) <- dummy;
           if tn.active > count then tn.active <- count;
           if count = 4 then (
             (* downgrade to [T4] to save space *)

--- a/lib/lwd/lwd.ml
+++ b/lib/lwd/lwd.ml
@@ -488,7 +488,9 @@ let sub_sample queue =
     | Operator t as self ->
       (* try to use cached value, if present *)
       match t.value with
-      | Eval_some value -> value
+      | Eval_some value ->
+        activate_tracing self origin t.trace;
+        value
       | _ ->
         t.value <- Eval_progress;
         let result : b = match t.desc with

--- a/lib/lwd/lwd.mli
+++ b/lib/lwd/lwd.mli
@@ -128,3 +128,6 @@ module Infix : sig
   val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
   val (<*>) : ('a -> 'b) t -> 'a t -> 'b t
 end
+
+(* For debug purposes *)
+val dump_trace : 'a t -> unit

--- a/lib/lwd/lwd_seq.ml
+++ b/lib/lwd/lwd_seq.ml
@@ -282,7 +282,7 @@ module Reducer = struct
         | Leaf t -> t.mark <- t.mark lor both_mask
         | Join t -> t.mark <- t.mark lor both_mask
       end;
-      begin match st.shared_x.(i) with
+      match st.shared_x.(i) with
       | [] -> assert false
       | [_] -> ()
       | xs -> st.shared_x.(i) <- List.rev xs

--- a/lib/lwd/lwd_seq.ml
+++ b/lib/lwd/lwd_seq.ml
@@ -1,0 +1,313 @@
+type +'a t =
+  | Nil
+  | Leaf of { mutable mark: int; v: 'a; }
+  | Join of { mutable mark: int; l: 'a t; r: 'a t; }
+
+type 'a seq = 'a t
+
+let empty = Nil
+
+let element v = Leaf { mark = 0; v }
+
+let concat a b = match a, b with
+  | Nil, x | x, Nil -> x
+  | l, r -> Join { mark = 0; l; r }
+
+type ('a, 'b) view =
+  | Empty
+  | Element of 'a
+  | Concat of 'b * 'b
+
+let view = function
+  | Nil    -> Empty
+  | Leaf t -> Element t.v
+  | Join t -> Concat (t.l, t.r)
+
+module Reducer = struct
+  type (+'a, 'b) xform =
+    | XEmpty
+    | XLeaf of { a: 'a t; mutable b: 'b option; }
+    | XJoin of { a: 'a t; mutable b: 'b option;
+                 l: ('a, 'b) xform; r: ('a, 'b) xform; }
+
+  type stats = {
+    mutable marked: int;
+    mutable shared: int;
+  }
+  let mk_stats () = { marked = 0; shared = 0 }
+
+  let mask_bits = 2
+  let old_mask = 1
+  let new_mask = 2
+  let both_mask = 3
+
+  let rec discard stats mask = function
+    | Nil -> ()
+    | Leaf t ->
+      let mark = t.mark in
+      if mark <> 0 && mark land mask = 0 then (
+        stats.marked <- stats.marked + 1;
+        stats.shared <- stats.shared + 1;
+        t.mark <- mark lor mask;
+      )
+    | Join t ->
+      let mark = t.mark in
+      if mark <> 0 && mark land mask = 0 then (
+        stats.marked <- stats.marked + 1;
+        stats.shared <- stats.shared + 1;
+        t.mark <- mark lor mask;
+        discard stats mask t.l;
+        discard stats mask t.r;
+      )
+
+  let enqueue stats q mask = function
+    | Nil -> ()
+    | Leaf t -> t.mark <- t.mark lor mask
+    | Join t as node ->
+      let mark = t.mark in
+      if mark land mask = 0 then (
+        stats.marked <- stats.marked + 1;
+        if mark = 0 then (
+          t.mark <- mask;
+          Queue.push node q
+        ) else (
+          stats.shared <- stats.shared + 1;
+          t.mark <- mark lor mask;
+          discard stats mask t.l;
+          discard stats mask t.r;
+        )
+      )
+
+  let dequeue stats q mask =
+    match Queue.pop q with
+    | Join t ->
+      if t.mark = mask then (
+        enqueue stats q mask t.l;
+        enqueue stats q mask t.r;
+      )
+    | _ -> assert false
+
+  let traverse1 stats q mask =
+    while not (Queue.is_empty q) do
+      dequeue stats q mask
+    done
+
+  let rec traverse sold snew qold qnew =
+    if Queue.is_empty qold then
+      traverse1 snew qnew new_mask
+    else if Queue.is_empty qnew then
+      traverse1 sold qold old_mask
+    else (
+      dequeue sold qold old_mask;
+      dequeue snew qnew new_mask;
+      traverse sold snew qold qnew
+    )
+
+  type ('a, 'b) unmark_state = {
+    dropped : 'b option array;
+    mutable dropped_leaf : int;
+    mutable dropped_join : int;
+    shared : ('a, 'b) xform array;
+    mutable shared_index: int;
+  }
+
+  let rec unmark_old st = function
+    | XEmpty -> ()
+    | XLeaf {a = Nil | Join _; _} -> assert false
+    | XJoin {a = Nil | Leaf _; _} -> assert false
+    | XLeaf {a = Leaf t'; b}  as t ->
+      let mark = t'.mark land both_mask in
+      if mark = old_mask then (
+        let dropped_leaf = st.dropped_leaf in
+        if dropped_leaf > -1 then (
+          st.dropped.(dropped_leaf) <- b;
+          st.dropped_leaf <- dropped_leaf + 1;
+        );
+        t'.mark <- 0
+      ) else if mark = both_mask then (
+        let shared_index = st.shared_index in
+        st.shared.(shared_index) <- t;
+        st.shared_index <- shared_index + 1;
+        t'.mark <- shared_index lsl mask_bits;
+      )
+    | XJoin {a = Join t'; l; r; b} as t ->
+      let mark = t'.mark land both_mask in
+      if mark <> 0 then (
+        if mark = old_mask then (
+          let dropped_join = st.dropped_join - 1 in
+          if dropped_join > -1 then (
+            st.dropped.(dropped_join) <- b;
+            st.dropped_join <- dropped_join;
+          );
+          t'.mark <- 0
+        )
+        else if mark = both_mask then (
+          let shared_index = st.shared_index in
+          st.shared.(shared_index) <- t;
+          st.shared_index <- shared_index + 1;
+          t'.mark <- shared_index lsl mask_bits;
+        );
+        unmark_old st l;
+        unmark_old st r;
+      )
+
+  let rec unmark_new st = function
+    | Nil -> XEmpty
+    | Leaf t' as t ->
+      let mark = t'.mark land both_mask in
+      if mark = new_mask then (
+        let shared_index = st.shared_index in
+        let x = XLeaf {a = t; b = None} in
+        st.shared.(shared_index) <- x;
+        st.shared_index <- shared_index + 1;
+        t'.mark <- shared_index lsl 2;
+        x
+      ) else (
+        assert (mark = 0);
+        st.shared.(t'.mark lsr mask_bits)
+      )
+    | Join t' as t ->
+      let mark = t'.mark land both_mask in
+      if mark = new_mask then (
+        let shared_index = st.shared_index in
+        st.shared_index <- shared_index + 1;
+        let l = unmark_new st t'.l in
+        let r = unmark_new st t'.r in
+        let x = XJoin {a = t; b = None; l; r} in
+        st.shared.(shared_index) <- x;
+        t'.mark <- shared_index lsl 2;
+        x
+      ) else (
+        assert (mark = 0);
+        st.shared.(t'.mark lsr mask_bits)
+      )
+
+  let diff get_dropped xold tnew = match xold, tnew with
+    | XEmpty, Nil -> 0, [||], XEmpty
+    | (XLeaf {a; _} | XJoin {a; _}), _ when a == tnew -> 0, [||], xold
+    | _ ->
+      let qold = Queue.create () in
+      let sold = mk_stats () in
+      let qnew = Queue.create () in
+      let snew = mk_stats () in
+      begin match xold with
+        | XEmpty -> ()
+        | (XLeaf {a; _} | XJoin {a; _}) ->
+          enqueue sold qold old_mask a
+      end;
+      enqueue snew qnew new_mask tnew;
+      traverse sold snew qold qnew;
+      let nb_shared = sold.shared + snew.shared in
+      let nb_dropped = sold.marked - nb_shared in
+      let st = {
+        dropped = if get_dropped then Array.make nb_dropped None else [||];
+        dropped_leaf = if get_dropped then 0 else -1;
+        dropped_join = if get_dropped then nb_dropped else -1;
+        shared = Array.make snew.marked XEmpty;
+        shared_index = 0;
+      } in
+      unmark_old st xold;
+      assert (st.dropped_leaf = st.dropped_join);
+      let result = unmark_new st tnew in
+      Array.iter (function
+          | XEmpty
+          | XLeaf {a = Nil | Join _; _}
+          | XJoin {a = Nil | Leaf _; _} -> assert false
+          | XLeaf {a = Leaf t; _} -> t.mark <- 0
+          | XJoin {a = Join t; _} -> t.mark <- 0
+        ) st.shared;
+      st.dropped_leaf, st.dropped, result
+
+  type ('a, 'b) map_reduce = ('a -> 'b) * ('b -> 'b -> 'b)
+  let map (f, _) x = f x
+  let reduce (_, f) x y = f x y
+
+  let eval map_reduce = function
+    | XEmpty -> None
+    | other ->
+      let rec aux = function
+        | XEmpty | XLeaf {a = Nil | Join _; _} -> assert false
+        | XLeaf {b = Some b; _} | XJoin {b = Some b; _} -> b
+        | XLeaf ({a = Leaf t';_ } as t) ->
+          let result = map map_reduce t'.v in
+          t.b <- Some result;
+          result
+        | XJoin t ->
+          let l = aux t.l and r = aux t.r in
+          let result = reduce map_reduce l r in
+          t.b <- Some result;
+          result
+      in
+      Some (aux other)
+
+  type ('a, 'b) reducer = ('a, 'b) map_reduce * ('a, 'b) xform
+
+  let make ~map ~reduce = ((map, reduce), XEmpty)
+
+  let reduce (map_reduce, tree : _ reducer) =
+    eval map_reduce tree
+
+  let update (map_reduce, old_tree : _ reducer) new_tree : _ reducer =
+    let _leaves, _dropped, tree = diff false old_tree new_tree in
+    (map_reduce, tree)
+
+  type 'b dropped = {
+    leaves: int;
+    table: 'b option array;
+  }
+
+  let update_and_get_dropped (map_reduce, old_tree : _ reducer) new_tree
+    : _ dropped * _ reducer =
+    let leaves, table, tree = diff true old_tree new_tree in
+    { leaves; table }, (map_reduce, tree)
+
+  let fold_dropped kind f dropped acc =
+    let acc = ref acc in
+    let start, bound = match kind with
+      | `All    -> 0, Array.length dropped.table
+      | `Map    -> 0, dropped.leaves
+      | `Reduce -> dropped.leaves, Array.length dropped.table
+    in
+    for i = start to bound - 1 do
+      match dropped.table.(i) with
+      | None -> ()
+      | Some x -> acc := f x !acc
+    done;
+    !acc
+end
+
+(* Lwd interface *)
+
+let fold ~map ~reduce seq =
+  let reducer = ref (Reducer.make ~map ~reduce) in
+  Lwd.map' seq @@ fun seq ->
+  let reducer' = Reducer.update !reducer seq in
+  reducer := reducer';
+  Reducer.reduce reducer'
+
+let fold_monoid map (zero, reduce) seq =
+  let reducer = ref (Reducer.make ~map ~reduce) in
+  Lwd.map' seq @@ fun seq ->
+  let reducer' = Reducer.update !reducer seq in
+  reducer := reducer';
+  match Reducer.reduce reducer' with
+  | None -> zero
+  | Some x -> x
+
+let monoid = (empty, concat)
+
+let map f seq =
+  fold_monoid (fun x -> element (f x)) monoid seq
+
+let filter f seq =
+  fold_monoid (fun x -> if f x then element x else empty) monoid seq
+
+let filter_map f seq =
+  let select x = match f x with
+    | Some y -> element y
+    | None -> empty
+  in
+  fold_monoid select monoid seq
+
+let lift (seq : 'a Lwd.t seq Lwd.t) : 'a seq Lwd.t =
+  Lwd.join (fold_monoid (Lwd.map element) (Lwd_utils.lift_monoid monoid) seq)

--- a/lib/lwd/lwd_seq.ml
+++ b/lib/lwd/lwd_seq.ml
@@ -113,13 +113,15 @@ module Reducer = struct
     | Nil -> ()
     | Leaf t' ->
       let mark = t'.mark in
-      if mark land both_mask <> both_mask then (
+      if mark land both_mask <> both_mask && mark land both_mask <> 0
+      then (
         new_blocked stats;
         t'.mark <- mark lor both_mask
       )
     | Join t' ->
       let mark = t'.mark in
-      if mark land both_mask <> both_mask then (
+      if mark land both_mask <> both_mask && mark land both_mask <> 0
+      then (
         new_blocked stats;
         t'.mark <- mark lor both_mask;
         block stats t'.l;
@@ -275,7 +277,12 @@ module Reducer = struct
 
   let prepare_shared st =
     for i = 0 to st.shared_index - 1 do
-      match st.shared_x.(i) with
+      begin match st.shared.(i) with
+        | Nil -> ()
+        | Leaf t -> t.mark <- t.mark lor both_mask
+        | Join t -> t.mark <- t.mark lor both_mask
+      end;
+      begin match st.shared_x.(i) with
       | [] -> assert false
       | [_] -> ()
       | xs -> st.shared_x.(i) <- List.rev xs

--- a/lib/lwd/lwd_seq.mli
+++ b/lib/lwd/lwd_seq.mli
@@ -1,11 +1,42 @@
-(* Sequence construction *)
+(* Sequence construction
+
+   [Lwd_seq] implements a type of ordered collections with a pure interface.
+   In addition, changes to collections are easy to track.
+
+   A collection can be transformed with the usual map, filter and fold
+   combinators. If later, the transformation is applied again to an updated
+   collection, shared elements (in the sense of physical sharing), the
+   result of the previous transformation will be reused for these elements.
+
+   The book-keeping overhead is O(n) in the number of changes, so O(1) per
+   element.
+*)
 
 type +'a t
 type +'a seq = 'a t
 
+(* A sequence with no element. *)
 val empty : 'a seq
+
+(* A singleton sequence. The physical identity of the element is considered
+   when reusing previous computations.
+
+   If you do:
+     let x1 = element x
+     let x2 = element x
+
+   Then x1 and x2 are seen as different elements and no sharing will be done
+   during transformation.
+*)
 val element : 'a -> 'a seq
+
+(* Concatenate two sequences into a bigger one.
+   As for [element], the physical identity of a sequence is considered for
+   reuse.
+*)
 val concat : 'a seq -> 'a seq -> 'a seq
+
+(* Look at the contents of a sequence *)
 
 type ('a, 'b) view =
   | Empty
@@ -15,6 +46,27 @@ type ('a, 'b) view =
 val view : 'a seq -> ('a, 'a seq) view
 
 module Balanced : sig
+  (* A variant of the sequence type that guarantees that the depth of
+     transformation, as measured in the number of [concat] nodes, grows in
+     O(log n) where n is the number of elements in the sequnce.
+
+     This is useful to prevent stack overflows and to avoid degenerate cases
+     where a single element change, but it is at the end of a linear sequence
+     of [concat] nodes, thus making the total work O(n).
+     For instance, in:
+
+       [concat e1 (concat e2 (concat e3 (... (concat e_n))...))]
+
+     If [e_n] changes, the whole spine has to be recomputed.
+
+     Using [Balanced.concat], the representation will be re-balanced
+     internally. Then [Balanced.view] should be used to access the balanced
+     sequence.
+
+     When working with balanced sequences in a transformation pipeline, it is
+     only useful to balance the first sequence of the pipeline. Derived
+     sequence will have a depth bounded by the depth of the first one.
+  *)
   type 'a t = private 'a seq
   val empty : 'a t
   val element : 'a -> 'a t
@@ -23,26 +75,72 @@ module Balanced : sig
   val view : 'a t -> ('a, 'a t) view
 end
 
-(* Lwd interface *)
+(* Lwd interface.
 
-val fold : map:('a -> 'b) -> reduce:('b -> 'b -> 'b) -> 'a seq Lwd.t -> 'b option Lwd.t
-val fold_monoid : ('a -> 'b) -> 'b Lwd_utils.monoid -> 'a seq Lwd.t -> 'b Lwd.t
-val map : ('a -> 'b) -> 'a seq Lwd.t -> 'b seq Lwd.t
-val filter : ('a -> bool) -> 'a seq Lwd.t -> 'a seq Lwd.t
-val filter_map : ('a -> 'b option) -> 'a seq Lwd.t -> 'b seq Lwd.t
+   All sequences live in [Lwd] monad: if a sequence changes slightly, parts
+   that have not changed will not be re-transformed.
+*)
+
+(* [fold ~map ~reduce] transforms a sequence.
+   If the sequence is non-empty, the [map] function is applied to element nodes
+   and the [reduce] function is used to combine transformed concatenated nodes.
+   If the sequence is empty, None is returned.
+*)
+val fold :
+  map:('a -> 'b) -> reduce:('b -> 'b -> 'b) -> 'a seq Lwd.t -> 'b option Lwd.t
+
+val fold_monoid :
+  ('a -> 'b) -> 'b Lwd_utils.monoid -> 'a seq Lwd.t -> 'b Lwd.t
+
+(* [map f] transforms a sequence by applying [f] to each element. *)
+val map :
+  ('a -> 'b) -> 'a seq Lwd.t -> 'b seq Lwd.t
+
+val filter :
+  ('a -> bool) -> 'a seq Lwd.t -> 'a seq Lwd.t
+
+val filter_map :
+  ('a -> 'b option) -> 'a seq Lwd.t -> 'b seq Lwd.t
 
 val lift : 'a Lwd.t seq Lwd.t -> 'a seq Lwd.t
 
 (* Low-level interface *)
 
 module Reducer : sig
+  (* The interface allows to implement incremental sequence transformation
+     outside of the [Lwd] monad.
+     Actually, the Lwd functions above are implemented on top of this
+     interface.
+  *)
+
+  (* A [('a, 'b) reducer] value stores the state necessary to incrementally
+     transform an ['a seq] to ['b].
+     In essence, the Lwd functions just hide a reducer value.
+  *)
   type ('a, 'b) reducer
 
+  (* A new reducer that transforms sequences with the given [map] and [reduce]
+     functions.  The reducer starts from the [empty] sequence.  *)
   val make : map:('a -> 'b) -> reduce:('b -> 'b -> 'b) -> ('a, 'b) reducer
+
+  (* Updates the [reducer] to transform another sequence.
+     Intermediate nodes are reused when possible.
+     Only the "reuse plan" is computed by [update], actual transformation is
+     done by the [reduce] function.
+   *)
   val update : ('a, 'b) reducer -> 'a seq -> ('a, 'b) reducer
 
+  (* Returns the reduced ['b] value if the sequence is non-empty or [None] if
+     the sequence is empty.
+     Because transformation is done lazily, [reduce] is the only function
+     that can call [map] and [reduce].
+   *)
   val reduce : ('a, 'b) reducer -> 'b option
 
+  (* Sometimes it is important to track the elements that disappeared from a
+     sequence. The ['b dropped] type represent all the intermediate result that
+     were referenced by a reducer and are no longer after an update.
+  *)
   type 'b dropped
   val update_and_get_dropped :
     ('a, 'b) reducer -> 'a seq -> 'b dropped * ('a, 'b) reducer

--- a/lib/lwd/lwd_seq.mli
+++ b/lib/lwd/lwd_seq.mli
@@ -14,16 +14,14 @@ type ('a, 'b) view =
 
 val view : 'a seq -> ('a, 'a seq) view
 
-(* TODO: Balanced sequence construction
-   module Balanced : sig
-     type nonrec 'a t = private 'a seq
-     val empty : 'a t
-     val element : 'a -> 'a t
-     val concat : 'a t -> 'a t -> 'a t
+module Balanced : sig
+  type 'a t = private 'a seq
+  val empty : 'a t
+  val element : 'a -> 'a t
+  val concat : 'a t -> 'a t -> 'a t
 
-     val view : 'a t -> ('a, 'a t) view
-   end
-*)
+  val view : 'a t -> ('a, 'a t) view
+end
 
 (* Lwd interface *)
 

--- a/lib/lwd/lwd_seq.mli
+++ b/lib/lwd/lwd_seq.mli
@@ -1,0 +1,55 @@
+(* Sequence construction *)
+
+type +'a t
+type +'a seq = 'a t
+
+val empty : 'a seq
+val element : 'a -> 'a seq
+val concat : 'a seq -> 'a seq -> 'a seq
+
+type ('a, 'b) view =
+  | Empty
+  | Element of 'a
+  | Concat of 'b * 'b
+
+val view : 'a seq -> ('a, 'a seq) view
+
+(* TODO: Balanced sequence construction
+   module Balanced : sig
+     type nonrec 'a t = private 'a seq
+     val empty : 'a t
+     val element : 'a -> 'a t
+     val concat : 'a t -> 'a t -> 'a t
+
+     val view : 'a t -> ('a, 'a t) view
+   end
+*)
+
+(* Lwd interface *)
+
+val fold : map:('a -> 'b) -> reduce:('b -> 'b -> 'b) -> 'a seq Lwd.t -> 'b option Lwd.t
+val fold_monoid : ('a -> 'b) -> 'b Lwd_utils.monoid -> 'a seq Lwd.t -> 'b Lwd.t
+val map : ('a -> 'b) -> 'a seq Lwd.t -> 'b seq Lwd.t
+val filter : ('a -> bool) -> 'a seq Lwd.t -> 'a seq Lwd.t
+val filter_map : ('a -> 'b option) -> 'a seq Lwd.t -> 'b seq Lwd.t
+
+val lift : 'a Lwd.t seq Lwd.t -> 'a seq Lwd.t
+
+(* Low-level interface *)
+
+module Reducer : sig
+  type ('a, 'b) reducer
+
+  val make : map:('a -> 'b) -> reduce:('b -> 'b -> 'b) -> ('a, 'b) reducer
+  val update : ('a, 'b) reducer -> 'a seq -> ('a, 'b) reducer
+
+  val reduce : ('a, 'b) reducer -> 'b option
+
+  type 'b dropped
+  val update_and_get_dropped :
+    ('a, 'b) reducer -> 'a seq -> 'b dropped * ('a, 'b) reducer
+
+  val fold_dropped :
+    [<`All|`Map|`Reduce] -> ('a -> 'b -> 'b) -> 'a dropped -> 'b -> 'b
+end
+

--- a/lib/nottui/nottui.ml
+++ b/lib/nottui/nottui.ml
@@ -204,6 +204,10 @@ struct
 
   let layout_spec t : layout_spec =
     { w = t.w; h = t.h; sw = t.sw; sh = t.sh }
+  let layout_width t = t.w
+  let layout_stretch_width t = t.sw
+  let layout_height t = t.h
+  let layout_stretch_height t = t.sh
 
   let cache : cache =
     { vx1 = 0; vy1 = 0; vx2 = 0; vy2 = 0;

--- a/lib/nottui/nottui.mli
+++ b/lib/nottui/nottui.mli
@@ -94,6 +94,10 @@ sig
       space. *)
 
   val layout_spec : t -> layout_spec
+  val layout_width : t -> int
+  val layout_stretch_width : t -> int
+  val layout_height : t -> int
+  val layout_stretch_height : t -> int
 end
 
 type ui = Ui.t


### PR DESCRIPTION
WIP: Wrong! The "GC" algorithm used to traverse datastructure is wrong. It misses a priority queue to order the traversal.

It solves problems similar to `Lwd_table`.

But while `Lwd_table` is used in an imperative fashion, `Lwd_seq` is used in a pure way.
E.g. to make interactive versions of a program, this translation can help:

| \ | inert  | live |
|  ------------- | ------------- | ------------- |
| **imperative** | array, doubly-linked list  | `Lwq_table`  |
| **functional** | map, list  | `Lwd_seq`  |
