### PR TITLE
Add pure modules in Tyxml_lwd

### DIFF
--- a/lib/tyxml-lwd/tyxml_lwd.ml
+++ b/lib/tyxml-lwd/tyxml_lwd.ml
@@ -1824,3 +1824,882 @@ module Lwdom = struct
 
   let to_node x = x
 end
+
+let pure_arg f x = f (Lwd.pure x)
+
+let pure_snd_arg f x1 x2 = f x1 (Lwd.pure x2)
+
+let pure_opt_arg f x = f (Lwd.pure (Some x))
+
+module Pure_html = struct
+  include Html
+
+  let a_class = pure_arg Html.a_class
+
+  let a_user_data = pure_snd_arg Html.a_user_data
+
+  let a_id = pure_arg Html.a_id
+
+  let a_title = pure_arg Html.a_title
+
+  let a_xml_lang = pure_arg Html.a_xml_lang
+
+  let a_lang = pure_arg Html.a_lang
+
+  let a_onabort = pure_opt_arg Html.a_onabort
+
+  let a_onafterprint = pure_opt_arg Html.a_onafterprint
+
+  let a_onbeforeprint = pure_opt_arg Html.a_onbeforeprint
+
+  let a_onbeforeunload = pure_opt_arg Html.a_onbeforeunload
+
+  let a_onblur = pure_opt_arg Html.a_onblur
+
+  let a_oncanplay = pure_opt_arg Html.a_oncanplay
+
+  let a_oncanplaythrough = pure_opt_arg Html.a_oncanplaythrough
+
+  let a_onchange = pure_opt_arg Html.a_onchange
+
+  let a_ondurationchange = pure_opt_arg Html.a_ondurationchange
+
+  let a_onemptied = pure_opt_arg Html.a_onemptied
+
+  let a_onended = pure_opt_arg Html.a_onended
+
+  let a_onerror = pure_opt_arg Html.a_onerror
+
+  let a_onfocus = pure_opt_arg Html.a_onfocus
+
+  let a_onformchange = pure_opt_arg Html.a_onformchange
+
+  let a_onforminput = pure_opt_arg Html.a_onforminput
+
+  let a_onhashchange = pure_opt_arg Html.a_onhashchange
+
+  let a_oninput = pure_opt_arg Html.a_oninput
+
+  let a_oninvalid = pure_opt_arg Html.a_oninvalid
+
+  let a_onmousewheel = pure_opt_arg Html.a_onmousewheel
+
+  let a_onoffline = pure_opt_arg Html.a_onoffline
+
+  let a_ononline = pure_opt_arg Html.a_ononline
+
+  let a_onpause = pure_opt_arg Html.a_onpause
+
+  let a_onplay = pure_opt_arg Html.a_onplay
+
+  let a_onplaying = pure_opt_arg Html.a_onplaying
+
+  let a_onpagehide = pure_opt_arg Html.a_onpagehide
+
+  let a_onpageshow = pure_opt_arg Html.a_onpageshow
+
+  let a_onpopstate = pure_opt_arg Html.a_onpopstate
+
+  let a_onprogress = pure_opt_arg Html.a_onprogress
+
+  let a_onratechange = pure_opt_arg Html.a_onratechange
+
+  let a_onreadystatechange = pure_opt_arg Html.a_onreadystatechange
+
+  let a_onredo = pure_opt_arg Html.a_onredo
+
+  let a_onresize = pure_opt_arg Html.a_onresize
+
+  let a_onscroll = pure_opt_arg Html.a_onscroll
+
+  let a_onseeked = pure_opt_arg Html.a_onseeked
+
+  let a_onseeking = pure_opt_arg Html.a_onseeking
+
+  let a_onselect = pure_opt_arg Html.a_onselect
+
+  let a_onshow = pure_opt_arg Html.a_onshow
+
+  let a_onstalled = pure_opt_arg Html.a_onstalled
+
+  let a_onstorage = pure_opt_arg Html.a_onstorage
+
+  let a_onsubmit = pure_opt_arg Html.a_onsubmit
+
+  let a_onsuspend = pure_opt_arg Html.a_onsuspend
+
+  let a_ontimeupdate = pure_opt_arg Html.a_ontimeupdate
+
+  let a_onundo = pure_opt_arg Html.a_onundo
+
+  let a_onunload = pure_opt_arg Html.a_onunload
+
+  let a_onvolumechange = pure_opt_arg Html.a_onvolumechange
+
+  let a_onwaiting = pure_opt_arg Html.a_onwaiting
+
+  let a_onload = pure_opt_arg Html.a_onload
+
+  let a_onloadeddata = pure_opt_arg Html.a_onloadeddata
+
+  let a_onloadedmetadata = pure_opt_arg Html.a_onloadedmetadata
+
+  let a_onloadstart = pure_opt_arg Html.a_onloadstart
+
+  let a_onmessage = pure_opt_arg Html.a_onmessage
+
+  let a_onclick = pure_opt_arg Html.a_onclick
+
+  let a_oncontextmenu = pure_opt_arg Html.a_oncontextmenu
+
+  let a_ondblclick = pure_opt_arg Html.a_ondblclick
+
+  let a_ondrag = pure_opt_arg Html.a_ondrag
+
+  let a_ondragend = pure_opt_arg Html.a_ondragend
+
+  let a_ondragenter = pure_opt_arg Html.a_ondragenter
+
+  let a_ondragleave = pure_opt_arg Html.a_ondragleave
+
+  let a_ondragover = pure_opt_arg Html.a_ondragover
+
+  let a_ondragstart = pure_opt_arg Html.a_ondragstart
+
+  let a_ondrop = pure_opt_arg Html.a_ondrop
+
+  let a_onmousedown = pure_opt_arg Html.a_onmousedown
+
+  let a_onmouseup = pure_opt_arg Html.a_onmouseup
+
+  let a_onmouseover = pure_opt_arg Html.a_onmouseover
+
+  let a_onmousemove = pure_opt_arg Html.a_onmousemove
+
+  let a_onmouseout = pure_opt_arg Html.a_onmouseout
+
+  let a_ontouchstart = pure_opt_arg Html.a_ontouchstart
+
+  let a_ontouchend = pure_opt_arg Html.a_ontouchend
+
+  let a_ontouchmove = pure_opt_arg Html.a_ontouchmove
+
+  let a_ontouchcancel = pure_opt_arg Html.a_ontouchcancel
+
+  let a_onkeypress = pure_opt_arg Html.a_onkeypress
+
+  let a_onkeydown = pure_opt_arg Html.a_onkeydown
+
+  let a_onkeyup = pure_opt_arg Html.a_onkeyup
+
+  let a_allowfullscreen = Html.a_allowfullscreen
+
+  let a_allowpaymentrequest = Html.a_allowpaymentrequest
+
+  let a_autocomplete = pure_arg Html.a_autocomplete
+
+  let a_async = Html.a_async
+
+  let a_autofocus = Html.a_autofocus
+
+  let a_autoplay = Html.a_autoplay
+
+  let a_muted = Html.a_muted
+
+  let a_crossorigin = pure_arg Html.a_crossorigin
+
+  let a_integrity = pure_arg Html.a_integrity
+
+  let a_mediagroup = pure_arg Html.a_mediagroup
+
+  let a_challenge = pure_arg Html.a_challenge
+
+  let a_contenteditable = pure_arg Html.a_contenteditable
+
+  let a_contextmenu = pure_arg Html.a_contextmenu
+
+  let a_controls = Html.a_controls
+
+  let a_dir = pure_arg Html.a_dir
+
+  let a_draggable = pure_arg Html.a_draggable
+
+  let a_form = pure_arg Html.a_form
+
+  let a_formaction = pure_arg Html.a_formaction
+
+  let a_formenctype = pure_arg Html.a_formenctype
+
+  let a_formnovalidate = Html.a_formnovalidate
+
+  let a_formtarget = pure_arg Html.a_formtarget
+
+  let a_hidden = Html.a_hidden
+
+  let a_high = pure_arg Html.a_high
+
+  let a_icon = pure_arg Html.a_icon
+
+  let a_ismap = Html.a_ismap
+
+  let a_keytype = pure_arg Html.a_keytype
+
+  let a_list = pure_arg Html.a_list
+
+  let a_loop = Html.a_loop
+
+  let a_low = pure_arg Html.a_low
+
+  let a_max = pure_arg Html.a_max
+
+  let a_input_max = pure_arg Html.a_input_max
+
+  let a_min = pure_arg Html.a_min
+
+  let a_input_min = pure_arg Html.a_input_min
+
+  let a_inputmode = pure_arg Html.a_inputmode
+
+  let a_novalidate = Html.a_novalidate
+
+  let a_open = Html.a_open
+
+  let a_optimum = pure_arg Html.a_optimum
+
+  let a_pattern = pure_arg Html.a_pattern
+
+  let a_placeholder = pure_arg Html.a_placeholder
+
+  let a_poster = pure_arg Html.a_poster
+
+  let a_preload = pure_arg Html.a_preload
+
+  let a_pubdate = Html.a_pubdate
+
+  let a_radiogroup = pure_arg Html.a_radiogroup
+
+  let a_referrerpolicy = pure_arg Html.a_referrerpolicy
+
+  let a_required = Html.a_required
+
+  let a_reversed = Html.a_reversed
+
+  let a_sandbox = pure_arg Html.a_sandbox
+
+  let a_spellcheck = pure_arg Html.a_spellcheck
+
+  let a_scoped = Html.a_scoped
+
+  let a_seamless = Html.a_seamless
+
+  let a_sizes = pure_arg Html.a_sizes
+
+  let a_span = pure_arg Html.a_span
+
+  let a_srcset = pure_arg Html.a_srcset
+
+  let a_img_sizes = pure_arg Html.a_img_sizes
+
+  let a_start = pure_arg Html.a_start
+
+  let a_step = pure_arg Html.a_step
+
+  let a_wrap = pure_arg Html.a_wrap
+
+  let a_version = pure_arg Html.a_version
+
+  let a_xmlns = pure_arg Html.a_xmlns
+
+  let a_manifest = pure_arg Html.a_manifest
+
+  let a_cite = pure_arg Html.a_cite
+
+  let a_xml_space = pure_arg Html.a_xml_space
+
+  let a_accesskey = pure_arg Html.a_accesskey
+
+  let a_charset = pure_arg Html.a_charset
+
+  let a_accept_charset = pure_arg Html.a_accept_charset
+
+  let a_accept = pure_arg Html.a_accept
+
+  let a_href = pure_arg Html.a_href
+
+  let a_hreflang = pure_arg Html.a_hreflang
+
+  let a_download = pure_arg Html.a_download
+
+  let a_rel = pure_arg Html.a_rel
+
+  let a_tabindex = pure_arg Html.a_tabindex
+
+  let a_mime_type = pure_arg Html.a_mime_type
+
+  let a_datetime = pure_arg Html.a_datetime
+
+  let a_action = pure_arg Html.a_action
+
+  let a_checked = Html.a_checked
+
+  let a_cols = pure_arg Html.a_cols
+
+  let a_enctype = pure_arg Html.a_enctype
+
+  let a_label_for = pure_arg Html.a_label_for
+
+  let a_output_for = pure_arg Html.a_output_for
+
+  let a_maxlength = pure_arg Html.a_maxlength
+
+  let a_minlength = pure_arg Html.a_minlength
+
+  let a_method = pure_arg Html.a_method
+
+  let a_multiple = Html.a_multiple
+
+  let a_name = pure_arg Html.a_name
+
+  let a_rows = pure_arg Html.a_rows
+
+  let a_selected = Html.a_selected
+
+  let a_size = pure_arg Html.a_size
+
+  let a_src = pure_arg Html.a_src
+
+  let a_input_type = pure_arg Html.a_input_type
+
+  let a_text_value = pure_arg Html.a_text_value
+
+  let a_int_value = pure_arg Html.a_int_value
+
+  let a_value = pure_arg Html.a_value
+
+  let a_float_value = pure_arg Html.a_float_value
+
+  let a_disabled = Html.a_disabled
+
+  let a_readonly = Html.a_readonly
+
+  let a_button_type = pure_arg Html.a_button_type
+
+  let a_command_type = pure_arg Html.a_command_type
+
+  let a_menu_type = pure_arg Html.a_menu_type
+
+  let a_label = pure_arg Html.a_label
+
+  let a_colspan = pure_arg Html.a_colspan
+
+  let a_headers = pure_arg Html.a_headers
+
+  let a_rowspan = pure_arg Html.a_rowspan
+
+  let a_alt = pure_arg Html.a_alt
+
+  let a_height = pure_arg Html.a_height
+
+  let a_width = pure_arg Html.a_width
+
+  let a_shape = pure_arg Html.a_shape
+
+  let a_coords = pure_arg Html.a_coords
+
+  let a_usemap = pure_arg Html.a_usemap
+
+  let a_data = pure_arg Html.a_data
+
+  let a_scrolling = pure_arg Html.a_scrolling
+
+  let a_target = pure_arg Html.a_target
+
+  let a_content = pure_arg Html.a_content
+
+  let a_http_equiv = pure_arg Html.a_http_equiv
+
+  let a_defer = Html.a_defer
+
+  let a_media = pure_arg Html.a_media
+
+  let a_style = pure_arg Html.a_style
+
+  let a_property = pure_arg Html.a_property
+
+  let a_role = pure_arg Html.a_role
+
+  let a_aria = pure_snd_arg Html.a_aria
+
+  let txt = pure_arg Html.txt
+
+  let bdo ~dir = Html.bdo ~dir:(Lwd.pure dir)
+  let img ~src ~alt = Html.img ~src:(Lwd.pure src) ~alt:(Lwd.pure alt)
+
+  let audio ?src  = Html.audio ?src:(Option.map Lwd.pure src)
+  let video ?src = Html.video ?src:(Option.map Lwd.pure src)
+  let area ~alt = Html.area ~alt:(Lwd.pure alt)
+  let optgroup ~label = Html.optgroup ~label:(Lwd.pure label)
+  let command ~label = Html.command ~label:(Lwd.pure label)
+  let link ~rel ~href = Html.link ~rel:(Lwd.pure rel) ~href:(Lwd.pure href)
+end
+
+module Pure_svg = struct
+  include Svg
+
+  let a_x = pure_arg Svg.a_x
+
+  let a_y = pure_arg Svg.a_y
+
+  let a_width = pure_arg Svg.a_width
+
+  let a_height = pure_arg Svg.a_height
+
+  let a_preserveAspectRatio = pure_arg Svg.a_preserveAspectRatio
+
+  let a_zoomAndPan = pure_arg Svg.a_zoomAndPan
+
+  let a_href = pure_arg Svg.a_href
+
+  let a_requiredExtensions = pure_arg Svg.a_requiredExtensions
+
+  let a_systemLanguage = pure_arg Svg.a_systemLanguage
+
+  let a_externalRessourcesRequired =
+    pure_arg Svg.a_externalRessourcesRequired
+
+  let a_id = pure_arg Svg.a_id
+
+  let a_user_data = pure_snd_arg Svg.a_user_data
+
+  let a_xml_lang = pure_arg Svg.a_xml_lang
+
+  let a_type = pure_arg Svg.a_type
+
+  let a_media = pure_arg Svg.a_media
+
+  let a_class = pure_arg Svg.a_class
+
+  let a_style = pure_arg Svg.a_style
+
+  let a_transform = pure_arg Svg.a_transform
+
+  let a_viewBox = pure_arg Svg.a_viewBox
+
+  let a_d = pure_arg Svg.a_d
+
+  let a_pathLength = pure_arg Svg.a_pathLength
+
+  let a_rx = pure_arg Svg.a_rx
+
+  let a_ry = pure_arg Svg.a_ry
+
+  let a_cx = pure_arg Svg.a_cx
+
+  let a_cy = pure_arg Svg.a_cy
+
+  let a_r = pure_arg Svg.a_r
+
+  let a_x1 = pure_arg Svg.a_x1
+
+  let a_y1 = pure_arg Svg.a_y1
+
+  let a_x2 = pure_arg Svg.a_x2
+
+  let a_y2 = pure_arg Svg.a_y2
+
+  let a_points = pure_arg Svg.a_points
+
+  let a_x_list = pure_arg Svg.a_x_list
+
+  let a_y_list = pure_arg Svg.a_y_list
+
+  let a_dx = pure_arg Svg.a_dx
+
+  let a_dy = pure_arg Svg.a_dy
+
+  let a_dx_list = pure_arg Svg.a_dx_list
+
+  let a_dy_list = pure_arg Svg.a_dy_list
+
+  let a_lengthAdjust = pure_arg Svg.a_lengthAdjust
+
+  let a_textLength = pure_arg Svg.a_textLength
+
+  let a_text_anchor = pure_arg Svg.a_text_anchor
+
+  let a_text_decoration = pure_arg Svg.a_text_decoration
+
+  let a_text_rendering = pure_arg Svg.a_text_rendering
+
+  let a_rotate = pure_arg Svg.a_rotate
+
+  let a_startOffset = pure_arg Svg.a_startOffset
+
+  let a_method = pure_arg Svg.a_method
+
+  let a_spacing = pure_arg Svg.a_spacing
+
+  let a_glyphRef = pure_arg Svg.a_glyphRef
+
+  let a_format = pure_arg Svg.a_format
+
+  let a_markerUnits = pure_arg Svg.a_markerUnits
+
+  let a_refX = pure_arg Svg.a_refX
+
+  let a_refY = pure_arg Svg.a_refY
+
+  let a_markerWidth = pure_arg Svg.a_markerWidth
+
+  let a_markerHeight = pure_arg Svg.a_markerHeight
+
+  let a_orient = pure_arg Svg.a_orient
+
+  let a_local = pure_arg Svg.a_local
+
+  let a_rendering_intent = pure_arg Svg.a_rendering_intent
+
+  let a_gradientUnits = pure_arg Svg.a_gradientUnits
+
+  let a_gradientTransform = pure_arg Svg.a_gradientTransform
+
+  let a_spreadMethod = pure_arg Svg.a_spreadMethod
+
+  let a_fx = pure_arg Svg.a_fx
+
+  let a_fy = pure_arg Svg.a_fy
+
+  let a_offset = pure_arg Svg.a_offset
+
+  let a_patternUnits = pure_arg Svg.a_patternUnits
+
+  let a_patternContentUnits = pure_arg Svg.a_patternContentUnits
+
+  let a_patternTransform = pure_arg Svg.a_patternTransform
+
+  let a_clipPathUnits = pure_arg Svg.a_clipPathUnits
+
+  let a_maskUnits = pure_arg Svg.a_maskUnits
+
+  let a_maskContentUnits = pure_arg Svg.a_maskContentUnits
+
+  let a_primitiveUnits = pure_arg Svg.a_primitiveUnits
+
+  let a_filterRes = pure_arg Svg.a_filterRes
+
+  let a_result = pure_arg Svg.a_result
+
+  let a_in = pure_arg Svg.a_in
+
+  let a_in2 = pure_arg Svg.a_in2
+
+  let a_azimuth = pure_arg Svg.a_azimuth
+
+  let a_elevation = pure_arg Svg.a_elevation
+
+  let a_pointsAtX = pure_arg Svg.a_pointsAtX
+
+  let a_pointsAtY = pure_arg Svg.a_pointsAtY
+
+  let a_pointsAtZ = pure_arg Svg.a_pointsAtZ
+
+  let a_specularExponent = pure_arg Svg.a_specularExponent
+
+  let a_specularConstant = pure_arg Svg.a_specularConstant
+
+  let a_limitingConeAngle = pure_arg Svg.a_limitingConeAngle
+
+  let a_mode = pure_arg Svg.a_mode
+
+  let a_feColorMatrix_type = pure_arg Svg.a_feColorMatrix_type
+
+  let a_values = pure_arg Svg.a_values
+
+  let a_transfer_type = pure_arg Svg.a_transfer_type
+
+  let a_tableValues = pure_arg Svg.a_tableValues
+
+  let a_intercept = pure_arg Svg.a_intercept
+
+  let a_amplitude = pure_arg Svg.a_amplitude
+
+  let a_exponent = pure_arg Svg.a_exponent
+
+  let a_transfer_offset = pure_arg Svg.a_transfer_offset
+
+  let a_feComposite_operator = pure_arg Svg.a_feComposite_operator
+
+  let a_k1 = pure_arg Svg.a_k1
+
+  let a_k2 = pure_arg Svg.a_k2
+
+  let a_k3 = pure_arg Svg.a_k3
+
+  let a_k4 = pure_arg Svg.a_k4
+
+  let a_order = pure_arg Svg.a_order
+
+  let a_kernelMatrix = pure_arg Svg.a_kernelMatrix
+
+  let a_divisor = pure_arg Svg.a_divisor
+
+  let a_bias = pure_arg Svg.a_bias
+
+  let a_kernelUnitLength = pure_arg Svg.a_kernelUnitLength
+
+  let a_targetX = pure_arg Svg.a_targetX
+
+  let a_targetY = pure_arg Svg.a_targetY
+
+  let a_edgeMode = pure_arg Svg.a_edgeMode
+
+  let a_preserveAlpha = pure_arg Svg.a_preserveAlpha
+
+  let a_surfaceScale = pure_arg Svg.a_surfaceScale
+
+  let a_diffuseConstant = pure_arg Svg.a_diffuseConstant
+
+  let a_scale = pure_arg Svg.a_scale
+
+  let a_xChannelSelector = pure_arg Svg.a_xChannelSelector
+
+  let a_yChannelSelector = pure_arg Svg.a_yChannelSelector
+
+  let a_stdDeviation = pure_arg Svg.a_stdDeviation
+
+  let a_feMorphology_operator = pure_arg Svg.a_feMorphology_operator
+
+  let a_radius = pure_arg Svg.a_radius
+
+  let a_baseFrenquency = pure_arg Svg.a_baseFrenquency
+
+  let a_numOctaves = pure_arg Svg.a_numOctaves
+
+  let a_seed = pure_arg Svg.a_seed
+
+  let a_stitchTiles = pure_arg Svg.a_stitchTiles
+
+  let a_feTurbulence_type = pure_arg Svg.a_feTurbulence_type
+
+  let a_target = pure_arg Svg.a_target
+
+  let a_attributeName = pure_arg Svg.a_attributeName
+
+  let a_attributeType = pure_arg Svg.a_attributeType
+
+  let a_begin = pure_arg Svg.a_begin
+
+  let a_dur = pure_arg Svg.a_dur
+
+  let a_min = pure_arg Svg.a_min
+
+  let a_max = pure_arg Svg.a_max
+
+  let a_restart = pure_arg Svg.a_restart
+
+  let a_repeatCount = pure_arg Svg.a_repeatCount
+
+  let a_repeatDur = pure_arg Svg.a_repeatDur
+
+  let a_fill = pure_arg Svg.a_fill
+
+  let a_animation_fill = pure_arg Svg.a_animation_fill
+
+  let a_calcMode = pure_arg Svg.a_calcMode
+
+  let a_animation_values = pure_arg Svg.a_animation_values
+
+  let a_keyTimes = pure_arg Svg.a_keyTimes
+
+  let a_keySplines = pure_arg Svg.a_keySplines
+
+  let a_from = pure_arg Svg.a_from
+
+  let a_to = pure_arg Svg.a_to
+
+  let a_by = pure_arg Svg.a_by
+
+  let a_additive = pure_arg Svg.a_additive
+
+  let a_accumulate = pure_arg Svg.a_accumulate
+
+  let a_keyPoints = pure_arg Svg.a_keyPoints
+
+  let a_path = pure_arg Svg.a_path
+
+  let a_animateTransform_type = pure_arg Svg.a_animateTransform_type
+
+  let a_horiz_origin_x = pure_arg Svg.a_horiz_origin_x
+
+  let a_horiz_origin_y = pure_arg Svg.a_horiz_origin_y
+
+  let a_horiz_adv_x = pure_arg Svg.a_horiz_adv_x
+
+  let a_vert_origin_x = pure_arg Svg.a_vert_origin_x
+
+  let a_vert_origin_y = pure_arg Svg.a_vert_origin_y
+
+  let a_vert_adv_y = pure_arg Svg.a_vert_adv_y
+
+  let a_unicode = pure_arg Svg.a_unicode
+
+  let a_glyph_name = pure_arg Svg.a_glyph_name
+
+  let a_orientation = pure_arg Svg.a_orientation
+
+  let a_arabic_form = pure_arg Svg.a_arabic_form
+
+  let a_lang = pure_arg Svg.a_lang
+
+  let a_u1 = pure_arg Svg.a_u1
+
+  let a_u2 = pure_arg Svg.a_u2
+
+  let a_g1 = pure_arg Svg.a_g1
+
+  let a_g2 = pure_arg Svg.a_g2
+
+  let a_k = pure_arg Svg.a_k
+
+  let a_font_family = pure_arg Svg.a_font_family
+
+  let a_font_style = pure_arg Svg.a_font_style
+
+  let a_font_variant = pure_arg Svg.a_font_variant
+
+  let a_font_weight = pure_arg Svg.a_font_weight
+
+  let a_font_stretch = pure_arg Svg.a_font_stretch
+
+  let a_font_size = pure_arg Svg.a_font_size
+
+  let a_unicode_range = pure_arg Svg.a_unicode_range
+
+  let a_units_per_em = pure_arg Svg.a_units_per_em
+
+  let a_stemv = pure_arg Svg.a_stemv
+
+  let a_stemh = pure_arg Svg.a_stemh
+
+  let a_slope = pure_arg Svg.a_slope
+
+  let a_cap_height = pure_arg Svg.a_cap_height
+
+  let a_x_height = pure_arg Svg.a_x_height
+
+  let a_accent_height = pure_arg Svg.a_accent_height
+
+  let a_ascent = pure_arg Svg.a_ascent
+
+  let a_widths = pure_arg Svg.a_widths
+
+  let a_bbox = pure_arg Svg.a_bbox
+
+  let a_ideographic = pure_arg Svg.a_ideographic
+
+  let a_alphabetic = pure_arg Svg.a_alphabetic
+
+  let a_mathematical = pure_arg Svg.a_mathematical
+
+  let a_hanging = pure_arg Svg.a_hanging
+
+  let a_videographic = pure_arg Svg.a_videographic
+
+  let a_v_alphabetic = pure_arg Svg.a_v_alphabetic
+
+  let a_v_mathematical = pure_arg Svg.a_v_mathematical
+
+  let a_v_hanging = pure_arg Svg.a_v_hanging
+
+  let a_underline_position = pure_arg Svg.a_underline_position
+
+  let a_underline_thickness = pure_arg Svg.a_underline_thickness
+
+  let a_strikethrough_position = pure_arg Svg.a_strikethrough_position
+
+  let a_strikethrough_thickness =
+    pure_arg Svg.a_strikethrough_thickness
+
+  let a_overline_position = pure_arg Svg.a_overline_position
+
+  let a_overline_thickness = pure_arg Svg.a_overline_thickness
+
+  let a_string = pure_arg Svg.a_string
+
+  let a_name = pure_arg Svg.a_name
+
+  let a_alignment_baseline = pure_arg Svg.a_alignment_baseline
+
+  let a_dominant_baseline = pure_arg Svg.a_dominant_baseline
+
+  let a_stop_color = pure_arg Svg.a_stop_color
+
+  let a_stop_opacity = pure_arg Svg.a_stop_opacity
+
+  let a_stroke = pure_arg Svg.a_stroke
+
+  let a_stroke_width = pure_arg Svg.a_stroke_width
+
+  let a_stroke_linecap = pure_arg Svg.a_stroke_linecap
+
+  let a_stroke_linejoin = pure_arg Svg.a_stroke_linejoin
+
+  let a_stroke_miterlimit = pure_arg Svg.a_stroke_miterlimit
+
+  let a_stroke_dasharray = pure_arg Svg.a_stroke_dasharray
+
+  let a_stroke_dashoffset = pure_arg Svg.a_stroke_dashoffset
+
+  let a_stroke_opacity = pure_arg Svg.a_stroke_opacity
+
+  let a_onabort = pure_opt_arg Svg.a_onabort
+
+  let a_onactivate = pure_opt_arg Svg.a_onactivate
+
+  let a_onbegin = pure_opt_arg Svg.a_onbegin
+
+  let a_onend = pure_opt_arg Svg.a_onend
+
+  let a_onerror = pure_opt_arg Svg.a_onerror
+
+  let a_onfocusin = pure_opt_arg Svg.a_onfocusin
+
+  let a_onfocusout = pure_opt_arg Svg.a_onfocusout
+
+  let a_onrepeat = pure_opt_arg Svg.a_onrepeat
+
+  let a_onresize = pure_opt_arg Svg.a_onresize
+
+  let a_onscroll = pure_opt_arg Svg.a_onscroll
+
+  let a_onunload = pure_opt_arg Svg.a_onunload
+
+  let a_onzoom = pure_opt_arg Svg.a_onzoom
+
+  let a_onclick = pure_opt_arg Svg.a_onclick
+
+  let a_onmousedown = pure_opt_arg Svg.a_onmousedown
+
+  let a_onmouseup = pure_opt_arg Svg.a_onmouseup
+
+  let a_onmouseover = pure_opt_arg Svg.a_onmouseover
+
+  let a_onmouseout = pure_opt_arg Svg.a_onmouseout
+
+  let a_onmousemove = pure_opt_arg Svg.a_onmousemove
+
+  let a_ontouchstart = pure_opt_arg Svg.a_ontouchstart
+
+  let a_ontouchend = pure_opt_arg Svg.a_ontouchend
+
+  let a_ontouchmove = pure_opt_arg Svg.a_ontouchmove
+
+  let a_ontouchcancel = pure_opt_arg Svg.a_ontouchcancel
+
+  let txt = pure_arg Svg.txt
+end
+
+module Pure = struct
+  module Svg = Pure_svg
+  module Html = Pure_html
+end

--- a/lib/tyxml-lwd/tyxml_lwd.ml
+++ b/lib/tyxml-lwd/tyxml_lwd.ml
@@ -1825,178 +1825,172 @@ module Lwdom = struct
   let to_node x = x
 end
 
-let pure_arg f x = f (Lwd.pure x)
-
-let pure_snd_arg f x1 x2 = f x1 (Lwd.pure x2)
-
-let pure_opt_arg f x = f (Lwd.pure (Some x))
-
 module Pure_html = struct
   include Html
 
-  let a_class = pure_arg Html.a_class
+  let a_class x = Html.a_class (Lwd.pure x)
 
-  let a_user_data = pure_snd_arg Html.a_user_data
+  let a_user_data x y = Html.a_user_data x (Lwd.pure y)
 
-  let a_id = pure_arg Html.a_id
+  let a_id x = Html.a_id (Lwd.pure x)
 
-  let a_title = pure_arg Html.a_title
+  let a_title x = Html.a_title (Lwd.pure x)
 
-  let a_xml_lang = pure_arg Html.a_xml_lang
+  let a_xml_lang x = Html.a_xml_lang (Lwd.pure x)
 
-  let a_lang = pure_arg Html.a_lang
+  let a_lang x = Html.a_lang (Lwd.pure x)
 
-  let a_onabort = pure_opt_arg Html.a_onabort
+  let a_onabort x = Html.a_onabort (Lwd.pure (Some x))
 
-  let a_onafterprint = pure_opt_arg Html.a_onafterprint
+  let a_onafterprint x = Html.a_onafterprint (Lwd.pure (Some x))
 
-  let a_onbeforeprint = pure_opt_arg Html.a_onbeforeprint
+  let a_onbeforeprint x = Html.a_onbeforeprint (Lwd.pure (Some x))
 
-  let a_onbeforeunload = pure_opt_arg Html.a_onbeforeunload
+  let a_onbeforeunload x = Html.a_onbeforeunload (Lwd.pure (Some x))
 
-  let a_onblur = pure_opt_arg Html.a_onblur
+  let a_onblur x = Html.a_onblur (Lwd.pure (Some x))
 
-  let a_oncanplay = pure_opt_arg Html.a_oncanplay
+  let a_oncanplay x = Html.a_oncanplay (Lwd.pure (Some x))
 
-  let a_oncanplaythrough = pure_opt_arg Html.a_oncanplaythrough
+  let a_oncanplaythrough x = Html.a_oncanplaythrough (Lwd.pure (Some x))
 
-  let a_onchange = pure_opt_arg Html.a_onchange
+  let a_onchange x = Html.a_onchange (Lwd.pure (Some x))
 
-  let a_ondurationchange = pure_opt_arg Html.a_ondurationchange
+  let a_ondurationchange x = Html.a_ondurationchange (Lwd.pure (Some x))
 
-  let a_onemptied = pure_opt_arg Html.a_onemptied
+  let a_onemptied x = Html.a_onemptied (Lwd.pure (Some x))
 
-  let a_onended = pure_opt_arg Html.a_onended
+  let a_onended x = Html.a_onended (Lwd.pure (Some x))
 
-  let a_onerror = pure_opt_arg Html.a_onerror
+  let a_onerror x = Html.a_onerror (Lwd.pure (Some x))
 
-  let a_onfocus = pure_opt_arg Html.a_onfocus
+  let a_onfocus x = Html.a_onfocus (Lwd.pure (Some x))
 
-  let a_onformchange = pure_opt_arg Html.a_onformchange
+  let a_onformchange x = Html.a_onformchange (Lwd.pure (Some x))
 
-  let a_onforminput = pure_opt_arg Html.a_onforminput
+  let a_onforminput x = Html.a_onforminput (Lwd.pure (Some x))
 
-  let a_onhashchange = pure_opt_arg Html.a_onhashchange
+  let a_onhashchange x = Html.a_onhashchange (Lwd.pure (Some x))
 
-  let a_oninput = pure_opt_arg Html.a_oninput
+  let a_oninput x = Html.a_oninput (Lwd.pure (Some x))
 
-  let a_oninvalid = pure_opt_arg Html.a_oninvalid
+  let a_oninvalid x = Html.a_oninvalid (Lwd.pure (Some x))
 
-  let a_onmousewheel = pure_opt_arg Html.a_onmousewheel
+  let a_onmousewheel x = Html.a_onmousewheel (Lwd.pure (Some x))
 
-  let a_onoffline = pure_opt_arg Html.a_onoffline
+  let a_onoffline x = Html.a_onoffline (Lwd.pure (Some x))
 
-  let a_ononline = pure_opt_arg Html.a_ononline
+  let a_ononline x = Html.a_ononline (Lwd.pure (Some x))
 
-  let a_onpause = pure_opt_arg Html.a_onpause
+  let a_onpause x = Html.a_onpause (Lwd.pure (Some x))
 
-  let a_onplay = pure_opt_arg Html.a_onplay
+  let a_onplay x = Html.a_onplay (Lwd.pure (Some x))
 
-  let a_onplaying = pure_opt_arg Html.a_onplaying
+  let a_onplaying x = Html.a_onplaying (Lwd.pure (Some x))
 
-  let a_onpagehide = pure_opt_arg Html.a_onpagehide
+  let a_onpagehide x = Html.a_onpagehide (Lwd.pure (Some x))
 
-  let a_onpageshow = pure_opt_arg Html.a_onpageshow
+  let a_onpageshow x = Html.a_onpageshow (Lwd.pure (Some x))
 
-  let a_onpopstate = pure_opt_arg Html.a_onpopstate
+  let a_onpopstate x = Html.a_onpopstate (Lwd.pure (Some x))
 
-  let a_onprogress = pure_opt_arg Html.a_onprogress
+  let a_onprogress x = Html.a_onprogress (Lwd.pure (Some x))
 
-  let a_onratechange = pure_opt_arg Html.a_onratechange
+  let a_onratechange x = Html.a_onratechange (Lwd.pure (Some x))
 
-  let a_onreadystatechange = pure_opt_arg Html.a_onreadystatechange
+  let a_onreadystatechange x = Html.a_onreadystatechange (Lwd.pure (Some x))
 
-  let a_onredo = pure_opt_arg Html.a_onredo
+  let a_onredo x = Html.a_onredo (Lwd.pure (Some x))
 
-  let a_onresize = pure_opt_arg Html.a_onresize
+  let a_onresize x = Html.a_onresize (Lwd.pure (Some x))
 
-  let a_onscroll = pure_opt_arg Html.a_onscroll
+  let a_onscroll x = Html.a_onscroll (Lwd.pure (Some x))
 
-  let a_onseeked = pure_opt_arg Html.a_onseeked
+  let a_onseeked x = Html.a_onseeked (Lwd.pure (Some x))
 
-  let a_onseeking = pure_opt_arg Html.a_onseeking
+  let a_onseeking x = Html.a_onseeking (Lwd.pure (Some x))
 
-  let a_onselect = pure_opt_arg Html.a_onselect
+  let a_onselect x = Html.a_onselect (Lwd.pure (Some x))
 
-  let a_onshow = pure_opt_arg Html.a_onshow
+  let a_onshow x = Html.a_onshow (Lwd.pure (Some x))
 
-  let a_onstalled = pure_opt_arg Html.a_onstalled
+  let a_onstalled x = Html.a_onstalled (Lwd.pure (Some x))
 
-  let a_onstorage = pure_opt_arg Html.a_onstorage
+  let a_onstorage x = Html.a_onstorage (Lwd.pure (Some x))
 
-  let a_onsubmit = pure_opt_arg Html.a_onsubmit
+  let a_onsubmit x = Html.a_onsubmit (Lwd.pure (Some x))
 
-  let a_onsuspend = pure_opt_arg Html.a_onsuspend
+  let a_onsuspend x = Html.a_onsuspend (Lwd.pure (Some x))
 
-  let a_ontimeupdate = pure_opt_arg Html.a_ontimeupdate
+  let a_ontimeupdate x = Html.a_ontimeupdate (Lwd.pure (Some x))
 
-  let a_onundo = pure_opt_arg Html.a_onundo
+  let a_onundo x = Html.a_onundo (Lwd.pure (Some x))
 
-  let a_onunload = pure_opt_arg Html.a_onunload
+  let a_onunload x = Html.a_onunload (Lwd.pure (Some x))
 
-  let a_onvolumechange = pure_opt_arg Html.a_onvolumechange
+  let a_onvolumechange x = Html.a_onvolumechange (Lwd.pure (Some x))
 
-  let a_onwaiting = pure_opt_arg Html.a_onwaiting
+  let a_onwaiting x = Html.a_onwaiting (Lwd.pure (Some x))
 
-  let a_onload = pure_opt_arg Html.a_onload
+  let a_onload x = Html.a_onload (Lwd.pure (Some x))
 
-  let a_onloadeddata = pure_opt_arg Html.a_onloadeddata
+  let a_onloadeddata x = Html.a_onloadeddata (Lwd.pure (Some x))
 
-  let a_onloadedmetadata = pure_opt_arg Html.a_onloadedmetadata
+  let a_onloadedmetadata x = Html.a_onloadedmetadata (Lwd.pure (Some x))
 
-  let a_onloadstart = pure_opt_arg Html.a_onloadstart
+  let a_onloadstart x = Html.a_onloadstart (Lwd.pure (Some x))
 
-  let a_onmessage = pure_opt_arg Html.a_onmessage
+  let a_onmessage x = Html.a_onmessage (Lwd.pure (Some x))
 
-  let a_onclick = pure_opt_arg Html.a_onclick
+  let a_onclick x = Html.a_onclick (Lwd.pure (Some x))
 
-  let a_oncontextmenu = pure_opt_arg Html.a_oncontextmenu
+  let a_oncontextmenu x = Html.a_oncontextmenu (Lwd.pure (Some x))
 
-  let a_ondblclick = pure_opt_arg Html.a_ondblclick
+  let a_ondblclick x = Html.a_ondblclick (Lwd.pure (Some x))
 
-  let a_ondrag = pure_opt_arg Html.a_ondrag
+  let a_ondrag x = Html.a_ondrag (Lwd.pure (Some x))
 
-  let a_ondragend = pure_opt_arg Html.a_ondragend
+  let a_ondragend x = Html.a_ondragend (Lwd.pure (Some x))
 
-  let a_ondragenter = pure_opt_arg Html.a_ondragenter
+  let a_ondragenter x = Html.a_ondragenter (Lwd.pure (Some x))
 
-  let a_ondragleave = pure_opt_arg Html.a_ondragleave
+  let a_ondragleave x = Html.a_ondragleave (Lwd.pure (Some x))
 
-  let a_ondragover = pure_opt_arg Html.a_ondragover
+  let a_ondragover x = Html.a_ondragover (Lwd.pure (Some x))
 
-  let a_ondragstart = pure_opt_arg Html.a_ondragstart
+  let a_ondragstart x = Html.a_ondragstart (Lwd.pure (Some x))
 
-  let a_ondrop = pure_opt_arg Html.a_ondrop
+  let a_ondrop x = Html.a_ondrop (Lwd.pure (Some x))
 
-  let a_onmousedown = pure_opt_arg Html.a_onmousedown
+  let a_onmousedown x = Html.a_onmousedown (Lwd.pure (Some x))
 
-  let a_onmouseup = pure_opt_arg Html.a_onmouseup
+  let a_onmouseup x = Html.a_onmouseup (Lwd.pure (Some x))
 
-  let a_onmouseover = pure_opt_arg Html.a_onmouseover
+  let a_onmouseover x = Html.a_onmouseover (Lwd.pure (Some x))
 
-  let a_onmousemove = pure_opt_arg Html.a_onmousemove
+  let a_onmousemove x = Html.a_onmousemove (Lwd.pure (Some x))
 
-  let a_onmouseout = pure_opt_arg Html.a_onmouseout
+  let a_onmouseout x = Html.a_onmouseout (Lwd.pure (Some x))
 
-  let a_ontouchstart = pure_opt_arg Html.a_ontouchstart
+  let a_ontouchstart x = Html.a_ontouchstart (Lwd.pure (Some x))
 
-  let a_ontouchend = pure_opt_arg Html.a_ontouchend
+  let a_ontouchend x = Html.a_ontouchend (Lwd.pure (Some x))
 
-  let a_ontouchmove = pure_opt_arg Html.a_ontouchmove
+  let a_ontouchmove x = Html.a_ontouchmove (Lwd.pure (Some x))
 
-  let a_ontouchcancel = pure_opt_arg Html.a_ontouchcancel
+  let a_ontouchcancel x = Html.a_ontouchcancel (Lwd.pure (Some x))
 
-  let a_onkeypress = pure_opt_arg Html.a_onkeypress
+  let a_onkeypress x = Html.a_onkeypress (Lwd.pure (Some x))
 
-  let a_onkeydown = pure_opt_arg Html.a_onkeydown
+  let a_onkeydown x = Html.a_onkeydown (Lwd.pure (Some x))
 
-  let a_onkeyup = pure_opt_arg Html.a_onkeyup
+  let a_onkeyup x = Html.a_onkeyup (Lwd.pure (Some x))
 
   let a_allowfullscreen = Html.a_allowfullscreen
 
   let a_allowpaymentrequest = Html.a_allowpaymentrequest
 
-  let a_autocomplete = pure_arg Html.a_autocomplete
+  let a_autocomplete x = Html.a_autocomplete (Lwd.pure x)
 
   let a_async = Html.a_async
 
@@ -2006,231 +2000,231 @@ module Pure_html = struct
 
   let a_muted = Html.a_muted
 
-  let a_crossorigin = pure_arg Html.a_crossorigin
+  let a_crossorigin x =  Html.a_crossorigin (Lwd.pure x)
 
-  let a_integrity = pure_arg Html.a_integrity
+  let a_integrity x = Html.a_integrity (Lwd.pure x)
 
-  let a_mediagroup = pure_arg Html.a_mediagroup
+  let a_mediagroup x = Html.a_mediagroup (Lwd.pure x)
 
-  let a_challenge = pure_arg Html.a_challenge
+  let a_challenge x = Html.a_challenge (Lwd.pure x)
 
-  let a_contenteditable = pure_arg Html.a_contenteditable
+  let a_contenteditable x = Html.a_contenteditable (Lwd.pure x)
 
-  let a_contextmenu = pure_arg Html.a_contextmenu
+  let a_contextmenu x = Html.a_contextmenu (Lwd.pure x)
 
   let a_controls = Html.a_controls
 
-  let a_dir = pure_arg Html.a_dir
+  let a_dir x = Html.a_dir (Lwd.pure x)
 
-  let a_draggable = pure_arg Html.a_draggable
+  let a_draggable x = Html.a_draggable (Lwd.pure x)
 
-  let a_form = pure_arg Html.a_form
+  let a_form x = Html.a_form (Lwd.pure x)
 
-  let a_formaction = pure_arg Html.a_formaction
+  let a_formaction x = Html.a_formaction (Lwd.pure x)
 
-  let a_formenctype = pure_arg Html.a_formenctype
+  let a_formenctype x = Html.a_formenctype (Lwd.pure x)
 
   let a_formnovalidate = Html.a_formnovalidate
 
-  let a_formtarget = pure_arg Html.a_formtarget
+  let a_formtarget x = Html.a_formtarget (Lwd.pure x)
 
   let a_hidden = Html.a_hidden
 
-  let a_high = pure_arg Html.a_high
+  let a_high x = Html.a_high (Lwd.pure x)
 
-  let a_icon = pure_arg Html.a_icon
+  let a_icon x = Html.a_icon (Lwd.pure x)
 
   let a_ismap = Html.a_ismap
 
-  let a_keytype = pure_arg Html.a_keytype
+  let a_keytype x = Html.a_keytype (Lwd.pure x)
 
-  let a_list = pure_arg Html.a_list
+  let a_list x = Html.a_list (Lwd.pure x)
 
   let a_loop = Html.a_loop
 
-  let a_low = pure_arg Html.a_low
+  let a_low x = Html.a_low (Lwd.pure x)
 
-  let a_max = pure_arg Html.a_max
+  let a_max x = Html.a_max (Lwd.pure x)
 
-  let a_input_max = pure_arg Html.a_input_max
+  let a_input_max x = Html.a_input_max (Lwd.pure x)
 
-  let a_min = pure_arg Html.a_min
+  let a_min x = Html.a_min (Lwd.pure x)
 
-  let a_input_min = pure_arg Html.a_input_min
+  let a_input_min x = Html.a_input_min (Lwd.pure x)
 
-  let a_inputmode = pure_arg Html.a_inputmode
+  let a_inputmode x = Html.a_inputmode (Lwd.pure x)
 
   let a_novalidate = Html.a_novalidate
 
   let a_open = Html.a_open
 
-  let a_optimum = pure_arg Html.a_optimum
+  let a_optimum x = Html.a_optimum (Lwd.pure x)
 
-  let a_pattern = pure_arg Html.a_pattern
+  let a_pattern x = Html.a_pattern (Lwd.pure x)
 
-  let a_placeholder = pure_arg Html.a_placeholder
+  let a_placeholder x = Html.a_placeholder (Lwd.pure x)
 
-  let a_poster = pure_arg Html.a_poster
+  let a_poster x = Html.a_poster (Lwd.pure x)
 
-  let a_preload = pure_arg Html.a_preload
+  let a_preload x = Html.a_preload (Lwd.pure x)
 
   let a_pubdate = Html.a_pubdate
 
-  let a_radiogroup = pure_arg Html.a_radiogroup
+  let a_radiogroup x = Html.a_radiogroup (Lwd.pure x)
 
-  let a_referrerpolicy = pure_arg Html.a_referrerpolicy
+  let a_referrerpolicy x = Html.a_referrerpolicy (Lwd.pure x)
 
   let a_required = Html.a_required
 
   let a_reversed = Html.a_reversed
 
-  let a_sandbox = pure_arg Html.a_sandbox
+  let a_sandbox x = Html.a_sandbox (Lwd.pure x)
 
-  let a_spellcheck = pure_arg Html.a_spellcheck
+  let a_spellcheck x = Html.a_spellcheck (Lwd.pure x)
 
   let a_scoped = Html.a_scoped
 
   let a_seamless = Html.a_seamless
 
-  let a_sizes = pure_arg Html.a_sizes
+  let a_sizes x = Html.a_sizes (Lwd.pure x)
 
-  let a_span = pure_arg Html.a_span
+  let a_span x = Html.a_span (Lwd.pure x)
 
-  let a_srcset = pure_arg Html.a_srcset
+  let a_srcset x = Html.a_srcset (Lwd.pure x)
 
-  let a_img_sizes = pure_arg Html.a_img_sizes
+  let a_img_sizes x = Html.a_img_sizes (Lwd.pure x)
 
-  let a_start = pure_arg Html.a_start
+  let a_start x = Html.a_start (Lwd.pure x)
 
-  let a_step = pure_arg Html.a_step
+  let a_step x = Html.a_step (Lwd.pure x)
 
-  let a_wrap = pure_arg Html.a_wrap
+  let a_wrap x = Html.a_wrap (Lwd.pure x)
 
-  let a_version = pure_arg Html.a_version
+  let a_version x = Html.a_version (Lwd.pure x)
 
-  let a_xmlns = pure_arg Html.a_xmlns
+  let a_xmlns x = Html.a_xmlns (Lwd.pure x)
 
-  let a_manifest = pure_arg Html.a_manifest
+  let a_manifest x = Html.a_manifest (Lwd.pure x)
 
-  let a_cite = pure_arg Html.a_cite
+  let a_cite x = Html.a_cite (Lwd.pure x)
 
-  let a_xml_space = pure_arg Html.a_xml_space
+  let a_xml_space x = Html.a_xml_space (Lwd.pure x)
 
-  let a_accesskey = pure_arg Html.a_accesskey
+  let a_accesskey x = Html.a_accesskey (Lwd.pure x)
 
-  let a_charset = pure_arg Html.a_charset
+  let a_charset x = Html.a_charset (Lwd.pure x)
 
-  let a_accept_charset = pure_arg Html.a_accept_charset
+  let a_accept_charset x = Html.a_accept_charset (Lwd.pure x)
 
-  let a_accept = pure_arg Html.a_accept
+  let a_accept x = Html.a_accept (Lwd.pure x)
 
-  let a_href = pure_arg Html.a_href
+  let a_href x = Html.a_href (Lwd.pure x)
 
-  let a_hreflang = pure_arg Html.a_hreflang
+  let a_hreflang x = Html.a_hreflang (Lwd.pure x)
 
-  let a_download = pure_arg Html.a_download
+  let a_download x = Html.a_download (Lwd.pure x)
 
-  let a_rel = pure_arg Html.a_rel
+  let a_rel x = Html.a_rel (Lwd.pure x)
 
-  let a_tabindex = pure_arg Html.a_tabindex
+  let a_tabindex x = Html.a_tabindex (Lwd.pure x)
 
-  let a_mime_type = pure_arg Html.a_mime_type
+  let a_mime_type x = Html.a_mime_type (Lwd.pure x)
 
-  let a_datetime = pure_arg Html.a_datetime
+  let a_datetime x = Html.a_datetime (Lwd.pure x)
 
-  let a_action = pure_arg Html.a_action
+  let a_action x = Html.a_action (Lwd.pure x)
 
   let a_checked = Html.a_checked
 
-  let a_cols = pure_arg Html.a_cols
+  let a_cols x = Html.a_cols (Lwd.pure x)
 
-  let a_enctype = pure_arg Html.a_enctype
+  let a_enctype x = Html.a_enctype (Lwd.pure x)
 
-  let a_label_for = pure_arg Html.a_label_for
+  let a_label_for x = Html.a_label_for (Lwd.pure x)
 
-  let a_output_for = pure_arg Html.a_output_for
+  let a_output_for x = Html.a_output_for (Lwd.pure x)
 
-  let a_maxlength = pure_arg Html.a_maxlength
+  let a_maxlength x = Html.a_maxlength (Lwd.pure x)
 
-  let a_minlength = pure_arg Html.a_minlength
+  let a_minlength x = Html.a_minlength (Lwd.pure x)
 
-  let a_method = pure_arg Html.a_method
+  let a_method x = Html.a_method (Lwd.pure x)
 
   let a_multiple = Html.a_multiple
 
-  let a_name = pure_arg Html.a_name
+  let a_name x = Html.a_name (Lwd.pure x)
 
-  let a_rows = pure_arg Html.a_rows
+  let a_rows x = Html.a_rows (Lwd.pure x)
 
   let a_selected = Html.a_selected
 
-  let a_size = pure_arg Html.a_size
+  let a_size x = Html.a_size (Lwd.pure x)
 
-  let a_src = pure_arg Html.a_src
+  let a_src x = Html.a_src (Lwd.pure x)
 
-  let a_input_type = pure_arg Html.a_input_type
+  let a_input_type x = Html.a_input_type (Lwd.pure x)
 
-  let a_text_value = pure_arg Html.a_text_value
+  let a_text_value x = Html.a_text_value (Lwd.pure x)
 
-  let a_int_value = pure_arg Html.a_int_value
+  let a_int_value x = Html.a_int_value (Lwd.pure x)
 
-  let a_value = pure_arg Html.a_value
+  let a_value x = Html.a_value (Lwd.pure x)
 
-  let a_float_value = pure_arg Html.a_float_value
+  let a_float_value x = Html.a_float_value (Lwd.pure x)
 
   let a_disabled = Html.a_disabled
 
   let a_readonly = Html.a_readonly
 
-  let a_button_type = pure_arg Html.a_button_type
+  let a_button_type x = Html.a_button_type (Lwd.pure x)
 
-  let a_command_type = pure_arg Html.a_command_type
+  let a_command_type x = Html.a_command_type (Lwd.pure x)
 
-  let a_menu_type = pure_arg Html.a_menu_type
+  let a_menu_type x = Html.a_menu_type (Lwd.pure x)
 
-  let a_label = pure_arg Html.a_label
+  let a_label x = Html.a_label (Lwd.pure x)
 
-  let a_colspan = pure_arg Html.a_colspan
+  let a_colspan x = Html.a_colspan (Lwd.pure x)
 
-  let a_headers = pure_arg Html.a_headers
+  let a_headers x = Html.a_headers (Lwd.pure x)
 
-  let a_rowspan = pure_arg Html.a_rowspan
+  let a_rowspan x = Html.a_rowspan (Lwd.pure x)
 
-  let a_alt = pure_arg Html.a_alt
+  let a_alt x = Html.a_alt (Lwd.pure x)
 
-  let a_height = pure_arg Html.a_height
+  let a_height x = Html.a_height (Lwd.pure x)
 
-  let a_width = pure_arg Html.a_width
+  let a_width x = Html.a_width (Lwd.pure x)
 
-  let a_shape = pure_arg Html.a_shape
+  let a_shape x = Html.a_shape (Lwd.pure x)
 
-  let a_coords = pure_arg Html.a_coords
+  let a_coords x = Html.a_coords (Lwd.pure x)
 
-  let a_usemap = pure_arg Html.a_usemap
+  let a_usemap x = Html.a_usemap (Lwd.pure x)
 
-  let a_data = pure_arg Html.a_data
+  let a_data x = Html.a_data (Lwd.pure x)
 
-  let a_scrolling = pure_arg Html.a_scrolling
+  let a_scrolling x = Html.a_scrolling (Lwd.pure x)
 
-  let a_target = pure_arg Html.a_target
+  let a_target x = Html.a_target (Lwd.pure x)
 
-  let a_content = pure_arg Html.a_content
+  let a_content x = Html.a_content (Lwd.pure x)
 
-  let a_http_equiv = pure_arg Html.a_http_equiv
+  let a_http_equiv x = Html.a_http_equiv (Lwd.pure x)
 
   let a_defer = Html.a_defer
 
-  let a_media = pure_arg Html.a_media
+  let a_media x = Html.a_media (Lwd.pure x)
 
-  let a_style = pure_arg Html.a_style
+  let a_style x = Html.a_style (Lwd.pure x)
 
-  let a_property = pure_arg Html.a_property
+  let a_property x = Html.a_property (Lwd.pure x)
 
-  let a_role = pure_arg Html.a_role
+  let a_role x = Html.a_role (Lwd.pure x)
 
-  let a_aria = pure_snd_arg Html.a_aria
+  let a_aria x y = Html.a_aria x (Lwd.pure y)
 
-  let txt = pure_arg Html.txt
+  let txt x = Html.txt (Lwd.pure x)
 
   let bdo ~dir = Html.bdo ~dir:(Lwd.pure dir)
   let img ~src ~alt = Html.img ~src:(Lwd.pure src) ~alt:(Lwd.pure alt)
@@ -2246,457 +2240,457 @@ end
 module Pure_svg = struct
   include Svg
 
-  let a_x = pure_arg Svg.a_x
+  let a_x x = Svg.a_x (Lwd.pure x)
 
-  let a_y = pure_arg Svg.a_y
+  let a_y x = Svg.a_y (Lwd.pure x)
 
-  let a_width = pure_arg Svg.a_width
+  let a_width x = Svg.a_width (Lwd.pure x)
 
-  let a_height = pure_arg Svg.a_height
+  let a_height x = Svg.a_height (Lwd.pure x)
 
-  let a_preserveAspectRatio = pure_arg Svg.a_preserveAspectRatio
+  let a_preserveAspectRatio x = Svg.a_preserveAspectRatio (Lwd.pure x)
 
-  let a_zoomAndPan = pure_arg Svg.a_zoomAndPan
+  let a_zoomAndPan x = Svg.a_zoomAndPan (Lwd.pure x)
 
-  let a_href = pure_arg Svg.a_href
+  let a_href x = Svg.a_href (Lwd.pure x)
 
-  let a_requiredExtensions = pure_arg Svg.a_requiredExtensions
+  let a_requiredExtensions x = Svg.a_requiredExtensions (Lwd.pure x)
 
-  let a_systemLanguage = pure_arg Svg.a_systemLanguage
+  let a_systemLanguage x = Svg.a_systemLanguage (Lwd.pure x)
 
-  let a_externalRessourcesRequired =
-    pure_arg Svg.a_externalRessourcesRequired
+  let a_externalRessourcesRequired x =
+   Svg.a_externalRessourcesRequired (Lwd.pure x)
 
-  let a_id = pure_arg Svg.a_id
+  let a_id x = Svg.a_id (Lwd.pure x)
 
-  let a_user_data = pure_snd_arg Svg.a_user_data
+  let a_user_data x y = Svg.a_user_data x (Lwd.pure y)
 
-  let a_xml_lang = pure_arg Svg.a_xml_lang
+  let a_xml_lang x = Svg.a_xml_lang (Lwd.pure x)
 
-  let a_type = pure_arg Svg.a_type
+  let a_type x = Svg.a_type (Lwd.pure x)
 
-  let a_media = pure_arg Svg.a_media
+  let a_media x = Svg.a_media (Lwd.pure x)
 
-  let a_class = pure_arg Svg.a_class
+  let a_class x = Svg.a_class (Lwd.pure x)
 
-  let a_style = pure_arg Svg.a_style
+  let a_style x = Svg.a_style (Lwd.pure x)
 
-  let a_transform = pure_arg Svg.a_transform
+  let a_transform x = Svg.a_transform (Lwd.pure x)
 
-  let a_viewBox = pure_arg Svg.a_viewBox
+  let a_viewBox x = Svg.a_viewBox (Lwd.pure x)
 
-  let a_d = pure_arg Svg.a_d
+  let a_d x = Svg.a_d (Lwd.pure x)
 
-  let a_pathLength = pure_arg Svg.a_pathLength
+  let a_pathLength x = Svg.a_pathLength (Lwd.pure x)
 
-  let a_rx = pure_arg Svg.a_rx
+  let a_rx x = Svg.a_rx (Lwd.pure x)
 
-  let a_ry = pure_arg Svg.a_ry
+  let a_ry x = Svg.a_ry (Lwd.pure x)
 
-  let a_cx = pure_arg Svg.a_cx
+  let a_cx x = Svg.a_cx (Lwd.pure x)
 
-  let a_cy = pure_arg Svg.a_cy
+  let a_cy x = Svg.a_cy (Lwd.pure x)
 
-  let a_r = pure_arg Svg.a_r
+  let a_r x = Svg.a_r (Lwd.pure x)
 
-  let a_x1 = pure_arg Svg.a_x1
+  let a_x1 x = Svg.a_x1 (Lwd.pure x)
 
-  let a_y1 = pure_arg Svg.a_y1
+  let a_y1 x = Svg.a_y1 (Lwd.pure x)
 
-  let a_x2 = pure_arg Svg.a_x2
+  let a_x2 x = Svg.a_x2 (Lwd.pure x)
 
-  let a_y2 = pure_arg Svg.a_y2
+  let a_y2 x = Svg.a_y2 (Lwd.pure x)
 
-  let a_points = pure_arg Svg.a_points
+  let a_points x = Svg.a_points (Lwd.pure x)
 
-  let a_x_list = pure_arg Svg.a_x_list
+  let a_x_list x = Svg.a_x_list (Lwd.pure x)
 
-  let a_y_list = pure_arg Svg.a_y_list
+  let a_y_list x = Svg.a_y_list (Lwd.pure x)
 
-  let a_dx = pure_arg Svg.a_dx
+  let a_dx x = Svg.a_dx (Lwd.pure x)
 
-  let a_dy = pure_arg Svg.a_dy
+  let a_dy x = Svg.a_dy (Lwd.pure x)
 
-  let a_dx_list = pure_arg Svg.a_dx_list
+  let a_dx_list x = Svg.a_dx_list (Lwd.pure x)
 
-  let a_dy_list = pure_arg Svg.a_dy_list
+  let a_dy_list x = Svg.a_dy_list (Lwd.pure x)
 
-  let a_lengthAdjust = pure_arg Svg.a_lengthAdjust
+  let a_lengthAdjust x = Svg.a_lengthAdjust (Lwd.pure x)
 
-  let a_textLength = pure_arg Svg.a_textLength
+  let a_textLength x = Svg.a_textLength (Lwd.pure x)
 
-  let a_text_anchor = pure_arg Svg.a_text_anchor
+  let a_text_anchor x = Svg.a_text_anchor (Lwd.pure x)
 
-  let a_text_decoration = pure_arg Svg.a_text_decoration
+  let a_text_decoration x = Svg.a_text_decoration (Lwd.pure x)
 
-  let a_text_rendering = pure_arg Svg.a_text_rendering
+  let a_text_rendering x = Svg.a_text_rendering (Lwd.pure x)
 
-  let a_rotate = pure_arg Svg.a_rotate
+  let a_rotate x = Svg.a_rotate (Lwd.pure x)
 
-  let a_startOffset = pure_arg Svg.a_startOffset
+  let a_startOffset x = Svg.a_startOffset (Lwd.pure x)
 
-  let a_method = pure_arg Svg.a_method
+  let a_method x = Svg.a_method (Lwd.pure x)
 
-  let a_spacing = pure_arg Svg.a_spacing
+  let a_spacing x = Svg.a_spacing (Lwd.pure x)
 
-  let a_glyphRef = pure_arg Svg.a_glyphRef
+  let a_glyphRef x = Svg.a_glyphRef (Lwd.pure x)
 
-  let a_format = pure_arg Svg.a_format
+  let a_format x = Svg.a_format (Lwd.pure x)
 
-  let a_markerUnits = pure_arg Svg.a_markerUnits
+  let a_markerUnits x = Svg.a_markerUnits (Lwd.pure x)
 
-  let a_refX = pure_arg Svg.a_refX
+  let a_refX x = Svg.a_refX (Lwd.pure x)
 
-  let a_refY = pure_arg Svg.a_refY
+  let a_refY x = Svg.a_refY (Lwd.pure x)
 
-  let a_markerWidth = pure_arg Svg.a_markerWidth
+  let a_markerWidth x = Svg.a_markerWidth (Lwd.pure x)
 
-  let a_markerHeight = pure_arg Svg.a_markerHeight
+  let a_markerHeight x = Svg.a_markerHeight (Lwd.pure x)
 
-  let a_orient = pure_arg Svg.a_orient
+  let a_orient x = Svg.a_orient (Lwd.pure x)
 
-  let a_local = pure_arg Svg.a_local
+  let a_local x = Svg.a_local (Lwd.pure x)
 
-  let a_rendering_intent = pure_arg Svg.a_rendering_intent
+  let a_rendering_intent x = Svg.a_rendering_intent (Lwd.pure x)
 
-  let a_gradientUnits = pure_arg Svg.a_gradientUnits
+  let a_gradientUnits x = Svg.a_gradientUnits (Lwd.pure x)
 
-  let a_gradientTransform = pure_arg Svg.a_gradientTransform
+  let a_gradientTransform x = Svg.a_gradientTransform (Lwd.pure x)
 
-  let a_spreadMethod = pure_arg Svg.a_spreadMethod
+  let a_spreadMethod x = Svg.a_spreadMethod (Lwd.pure x)
 
-  let a_fx = pure_arg Svg.a_fx
+  let a_fx x = Svg.a_fx (Lwd.pure x)
 
-  let a_fy = pure_arg Svg.a_fy
+  let a_fy x = Svg.a_fy (Lwd.pure x)
 
-  let a_offset = pure_arg Svg.a_offset
+  let a_offset x = Svg.a_offset (Lwd.pure x)
 
-  let a_patternUnits = pure_arg Svg.a_patternUnits
+  let a_patternUnits x = Svg.a_patternUnits (Lwd.pure x)
 
-  let a_patternContentUnits = pure_arg Svg.a_patternContentUnits
+  let a_patternContentUnits x = Svg.a_patternContentUnits (Lwd.pure x)
 
-  let a_patternTransform = pure_arg Svg.a_patternTransform
+  let a_patternTransform x = Svg.a_patternTransform (Lwd.pure x)
 
-  let a_clipPathUnits = pure_arg Svg.a_clipPathUnits
+  let a_clipPathUnits x = Svg.a_clipPathUnits (Lwd.pure x)
 
-  let a_maskUnits = pure_arg Svg.a_maskUnits
+  let a_maskUnits x = Svg.a_maskUnits (Lwd.pure x)
 
-  let a_maskContentUnits = pure_arg Svg.a_maskContentUnits
+  let a_maskContentUnits x = Svg.a_maskContentUnits (Lwd.pure x)
 
-  let a_primitiveUnits = pure_arg Svg.a_primitiveUnits
+  let a_primitiveUnits x = Svg.a_primitiveUnits (Lwd.pure x)
 
-  let a_filterRes = pure_arg Svg.a_filterRes
+  let a_filterRes x = Svg.a_filterRes (Lwd.pure x)
 
-  let a_result = pure_arg Svg.a_result
+  let a_result x = Svg.a_result (Lwd.pure x)
 
-  let a_in = pure_arg Svg.a_in
+  let a_in x = Svg.a_in (Lwd.pure x)
 
-  let a_in2 = pure_arg Svg.a_in2
+  let a_in2 x = Svg.a_in2 (Lwd.pure x)
 
-  let a_azimuth = pure_arg Svg.a_azimuth
+  let a_azimuth x = Svg.a_azimuth (Lwd.pure x)
 
-  let a_elevation = pure_arg Svg.a_elevation
+  let a_elevation x = Svg.a_elevation (Lwd.pure x)
 
-  let a_pointsAtX = pure_arg Svg.a_pointsAtX
+  let a_pointsAtX x = Svg.a_pointsAtX (Lwd.pure x)
 
-  let a_pointsAtY = pure_arg Svg.a_pointsAtY
+  let a_pointsAtY x = Svg.a_pointsAtY (Lwd.pure x)
 
-  let a_pointsAtZ = pure_arg Svg.a_pointsAtZ
+  let a_pointsAtZ x = Svg.a_pointsAtZ (Lwd.pure x)
 
-  let a_specularExponent = pure_arg Svg.a_specularExponent
+  let a_specularExponent x = Svg.a_specularExponent (Lwd.pure x)
 
-  let a_specularConstant = pure_arg Svg.a_specularConstant
+  let a_specularConstant x = Svg.a_specularConstant (Lwd.pure x)
 
-  let a_limitingConeAngle = pure_arg Svg.a_limitingConeAngle
+  let a_limitingConeAngle x = Svg.a_limitingConeAngle (Lwd.pure x)
 
-  let a_mode = pure_arg Svg.a_mode
+  let a_mode x = Svg.a_mode (Lwd.pure x)
 
-  let a_feColorMatrix_type = pure_arg Svg.a_feColorMatrix_type
+  let a_feColorMatrix_type x = Svg.a_feColorMatrix_type (Lwd.pure x)
 
-  let a_values = pure_arg Svg.a_values
+  let a_values x = Svg.a_values (Lwd.pure x)
 
-  let a_transfer_type = pure_arg Svg.a_transfer_type
+  let a_transfer_type x = Svg.a_transfer_type (Lwd.pure x)
 
-  let a_tableValues = pure_arg Svg.a_tableValues
+  let a_tableValues x = Svg.a_tableValues (Lwd.pure x)
 
-  let a_intercept = pure_arg Svg.a_intercept
+  let a_intercept x = Svg.a_intercept (Lwd.pure x)
 
-  let a_amplitude = pure_arg Svg.a_amplitude
+  let a_amplitude x = Svg.a_amplitude (Lwd.pure x)
 
-  let a_exponent = pure_arg Svg.a_exponent
+  let a_exponent x = Svg.a_exponent (Lwd.pure x)
 
-  let a_transfer_offset = pure_arg Svg.a_transfer_offset
+  let a_transfer_offset x = Svg.a_transfer_offset (Lwd.pure x)
 
-  let a_feComposite_operator = pure_arg Svg.a_feComposite_operator
+  let a_feComposite_operator x = Svg.a_feComposite_operator (Lwd.pure x)
 
-  let a_k1 = pure_arg Svg.a_k1
+  let a_k1 x = Svg.a_k1 (Lwd.pure x)
 
-  let a_k2 = pure_arg Svg.a_k2
+  let a_k2 x = Svg.a_k2 (Lwd.pure x)
 
-  let a_k3 = pure_arg Svg.a_k3
+  let a_k3 x = Svg.a_k3 (Lwd.pure x)
 
-  let a_k4 = pure_arg Svg.a_k4
+  let a_k4 x = Svg.a_k4 (Lwd.pure x)
 
-  let a_order = pure_arg Svg.a_order
+  let a_order x = Svg.a_order (Lwd.pure x)
 
-  let a_kernelMatrix = pure_arg Svg.a_kernelMatrix
+  let a_kernelMatrix x = Svg.a_kernelMatrix (Lwd.pure x)
 
-  let a_divisor = pure_arg Svg.a_divisor
+  let a_divisor x = Svg.a_divisor (Lwd.pure x)
 
-  let a_bias = pure_arg Svg.a_bias
+  let a_bias x = Svg.a_bias (Lwd.pure x)
 
-  let a_kernelUnitLength = pure_arg Svg.a_kernelUnitLength
+  let a_kernelUnitLength x = Svg.a_kernelUnitLength (Lwd.pure x)
 
-  let a_targetX = pure_arg Svg.a_targetX
+  let a_targetX x = Svg.a_targetX (Lwd.pure x)
 
-  let a_targetY = pure_arg Svg.a_targetY
+  let a_targetY x = Svg.a_targetY (Lwd.pure x)
 
-  let a_edgeMode = pure_arg Svg.a_edgeMode
+  let a_edgeMode x = Svg.a_edgeMode (Lwd.pure x)
 
-  let a_preserveAlpha = pure_arg Svg.a_preserveAlpha
+  let a_preserveAlpha x = Svg.a_preserveAlpha (Lwd.pure x)
 
-  let a_surfaceScale = pure_arg Svg.a_surfaceScale
+  let a_surfaceScale x = Svg.a_surfaceScale (Lwd.pure x)
 
-  let a_diffuseConstant = pure_arg Svg.a_diffuseConstant
+  let a_diffuseConstant x = Svg.a_diffuseConstant (Lwd.pure x)
 
-  let a_scale = pure_arg Svg.a_scale
+  let a_scale x = Svg.a_scale (Lwd.pure x)
 
-  let a_xChannelSelector = pure_arg Svg.a_xChannelSelector
+  let a_xChannelSelector x = Svg.a_xChannelSelector (Lwd.pure x)
 
-  let a_yChannelSelector = pure_arg Svg.a_yChannelSelector
+  let a_yChannelSelector x = Svg.a_yChannelSelector (Lwd.pure x)
 
-  let a_stdDeviation = pure_arg Svg.a_stdDeviation
+  let a_stdDeviation x = Svg.a_stdDeviation (Lwd.pure x)
 
-  let a_feMorphology_operator = pure_arg Svg.a_feMorphology_operator
+  let a_feMorphology_operator x = Svg.a_feMorphology_operator (Lwd.pure x)
 
-  let a_radius = pure_arg Svg.a_radius
+  let a_radius x = Svg.a_radius (Lwd.pure x)
 
-  let a_baseFrenquency = pure_arg Svg.a_baseFrenquency
+  let a_baseFrenquency x = Svg.a_baseFrenquency (Lwd.pure x)
 
-  let a_numOctaves = pure_arg Svg.a_numOctaves
+  let a_numOctaves x = Svg.a_numOctaves (Lwd.pure x)
 
-  let a_seed = pure_arg Svg.a_seed
+  let a_seed x = Svg.a_seed (Lwd.pure x)
 
-  let a_stitchTiles = pure_arg Svg.a_stitchTiles
+  let a_stitchTiles x = Svg.a_stitchTiles (Lwd.pure x)
 
-  let a_feTurbulence_type = pure_arg Svg.a_feTurbulence_type
+  let a_feTurbulence_type x = Svg.a_feTurbulence_type (Lwd.pure x)
 
-  let a_target = pure_arg Svg.a_target
+  let a_target x = Svg.a_target (Lwd.pure x)
 
-  let a_attributeName = pure_arg Svg.a_attributeName
+  let a_attributeName x = Svg.a_attributeName (Lwd.pure x)
 
-  let a_attributeType = pure_arg Svg.a_attributeType
+  let a_attributeType x = Svg.a_attributeType (Lwd.pure x)
 
-  let a_begin = pure_arg Svg.a_begin
+  let a_begin x = Svg.a_begin (Lwd.pure x)
 
-  let a_dur = pure_arg Svg.a_dur
+  let a_dur x = Svg.a_dur (Lwd.pure x)
 
-  let a_min = pure_arg Svg.a_min
+  let a_min x = Svg.a_min (Lwd.pure x)
 
-  let a_max = pure_arg Svg.a_max
+  let a_max x = Svg.a_max (Lwd.pure x)
 
-  let a_restart = pure_arg Svg.a_restart
+  let a_restart x = Svg.a_restart (Lwd.pure x)
 
-  let a_repeatCount = pure_arg Svg.a_repeatCount
+  let a_repeatCount x = Svg.a_repeatCount (Lwd.pure x)
 
-  let a_repeatDur = pure_arg Svg.a_repeatDur
+  let a_repeatDur x = Svg.a_repeatDur (Lwd.pure x)
 
-  let a_fill = pure_arg Svg.a_fill
+  let a_fill x = Svg.a_fill (Lwd.pure x)
 
-  let a_animation_fill = pure_arg Svg.a_animation_fill
+  let a_animation_fill x = Svg.a_animation_fill (Lwd.pure x)
 
-  let a_calcMode = pure_arg Svg.a_calcMode
+  let a_calcMode x = Svg.a_calcMode (Lwd.pure x)
 
-  let a_animation_values = pure_arg Svg.a_animation_values
+  let a_animation_values x = Svg.a_animation_values (Lwd.pure x)
 
-  let a_keyTimes = pure_arg Svg.a_keyTimes
+  let a_keyTimes x = Svg.a_keyTimes (Lwd.pure x)
 
-  let a_keySplines = pure_arg Svg.a_keySplines
+  let a_keySplines x = Svg.a_keySplines (Lwd.pure x)
 
-  let a_from = pure_arg Svg.a_from
+  let a_from x = Svg.a_from (Lwd.pure x)
 
-  let a_to = pure_arg Svg.a_to
+  let a_to x = Svg.a_to (Lwd.pure x)
 
-  let a_by = pure_arg Svg.a_by
+  let a_by x = Svg.a_by (Lwd.pure x)
 
-  let a_additive = pure_arg Svg.a_additive
+  let a_additive x = Svg.a_additive (Lwd.pure x)
 
-  let a_accumulate = pure_arg Svg.a_accumulate
+  let a_accumulate x = Svg.a_accumulate (Lwd.pure x)
 
-  let a_keyPoints = pure_arg Svg.a_keyPoints
+  let a_keyPoints x = Svg.a_keyPoints (Lwd.pure x)
 
-  let a_path = pure_arg Svg.a_path
+  let a_path x = Svg.a_path (Lwd.pure x)
 
-  let a_animateTransform_type = pure_arg Svg.a_animateTransform_type
+  let a_animateTransform_type x = Svg.a_animateTransform_type (Lwd.pure x)
 
-  let a_horiz_origin_x = pure_arg Svg.a_horiz_origin_x
+  let a_horiz_origin_x x = Svg.a_horiz_origin_x (Lwd.pure x)
 
-  let a_horiz_origin_y = pure_arg Svg.a_horiz_origin_y
+  let a_horiz_origin_y x = Svg.a_horiz_origin_y (Lwd.pure x)
 
-  let a_horiz_adv_x = pure_arg Svg.a_horiz_adv_x
+  let a_horiz_adv_x x = Svg.a_horiz_adv_x (Lwd.pure x)
 
-  let a_vert_origin_x = pure_arg Svg.a_vert_origin_x
+  let a_vert_origin_x x = Svg.a_vert_origin_x (Lwd.pure x)
 
-  let a_vert_origin_y = pure_arg Svg.a_vert_origin_y
+  let a_vert_origin_y x = Svg.a_vert_origin_y (Lwd.pure x)
 
-  let a_vert_adv_y = pure_arg Svg.a_vert_adv_y
+  let a_vert_adv_y x = Svg.a_vert_adv_y (Lwd.pure x)
 
-  let a_unicode = pure_arg Svg.a_unicode
+  let a_unicode x = Svg.a_unicode (Lwd.pure x)
 
-  let a_glyph_name = pure_arg Svg.a_glyph_name
+  let a_glyph_name x = Svg.a_glyph_name (Lwd.pure x)
 
-  let a_orientation = pure_arg Svg.a_orientation
+  let a_orientation x = Svg.a_orientation (Lwd.pure x)
 
-  let a_arabic_form = pure_arg Svg.a_arabic_form
+  let a_arabic_form x = Svg.a_arabic_form (Lwd.pure x)
 
-  let a_lang = pure_arg Svg.a_lang
+  let a_lang x = Svg.a_lang (Lwd.pure x)
 
-  let a_u1 = pure_arg Svg.a_u1
+  let a_u1 x = Svg.a_u1 (Lwd.pure x)
 
-  let a_u2 = pure_arg Svg.a_u2
+  let a_u2 x = Svg.a_u2 (Lwd.pure x)
 
-  let a_g1 = pure_arg Svg.a_g1
+  let a_g1 x = Svg.a_g1 (Lwd.pure x)
 
-  let a_g2 = pure_arg Svg.a_g2
+  let a_g2 x = Svg.a_g2 (Lwd.pure x)
 
-  let a_k = pure_arg Svg.a_k
+  let a_k x = Svg.a_k (Lwd.pure x)
 
-  let a_font_family = pure_arg Svg.a_font_family
+  let a_font_family x = Svg.a_font_family (Lwd.pure x)
 
-  let a_font_style = pure_arg Svg.a_font_style
+  let a_font_style x = Svg.a_font_style (Lwd.pure x)
 
-  let a_font_variant = pure_arg Svg.a_font_variant
+  let a_font_variant x = Svg.a_font_variant (Lwd.pure x)
 
-  let a_font_weight = pure_arg Svg.a_font_weight
+  let a_font_weight x = Svg.a_font_weight (Lwd.pure x)
 
-  let a_font_stretch = pure_arg Svg.a_font_stretch
+  let a_font_stretch x = Svg.a_font_stretch (Lwd.pure x)
 
-  let a_font_size = pure_arg Svg.a_font_size
+  let a_font_size x = Svg.a_font_size (Lwd.pure x)
 
-  let a_unicode_range = pure_arg Svg.a_unicode_range
+  let a_unicode_range x = Svg.a_unicode_range (Lwd.pure x)
 
-  let a_units_per_em = pure_arg Svg.a_units_per_em
+  let a_units_per_em x = Svg.a_units_per_em (Lwd.pure x)
 
-  let a_stemv = pure_arg Svg.a_stemv
+  let a_stemv x = Svg.a_stemv (Lwd.pure x)
 
-  let a_stemh = pure_arg Svg.a_stemh
+  let a_stemh x = Svg.a_stemh (Lwd.pure x)
 
-  let a_slope = pure_arg Svg.a_slope
+  let a_slope x = Svg.a_slope (Lwd.pure x)
 
-  let a_cap_height = pure_arg Svg.a_cap_height
+  let a_cap_height x = Svg.a_cap_height (Lwd.pure x)
 
-  let a_x_height = pure_arg Svg.a_x_height
+  let a_x_height x = Svg.a_x_height (Lwd.pure x)
 
-  let a_accent_height = pure_arg Svg.a_accent_height
+  let a_accent_height x = Svg.a_accent_height (Lwd.pure x)
 
-  let a_ascent = pure_arg Svg.a_ascent
+  let a_ascent x = Svg.a_ascent (Lwd.pure x)
 
-  let a_widths = pure_arg Svg.a_widths
+  let a_widths x = Svg.a_widths (Lwd.pure x)
 
-  let a_bbox = pure_arg Svg.a_bbox
+  let a_bbox x = Svg.a_bbox (Lwd.pure x)
 
-  let a_ideographic = pure_arg Svg.a_ideographic
+  let a_ideographic x = Svg.a_ideographic (Lwd.pure x)
 
-  let a_alphabetic = pure_arg Svg.a_alphabetic
+  let a_alphabetic x = Svg.a_alphabetic (Lwd.pure x)
 
-  let a_mathematical = pure_arg Svg.a_mathematical
+  let a_mathematical x = Svg.a_mathematical (Lwd.pure x)
 
-  let a_hanging = pure_arg Svg.a_hanging
+  let a_hanging x = Svg.a_hanging (Lwd.pure x)
 
-  let a_videographic = pure_arg Svg.a_videographic
+  let a_videographic x = Svg.a_videographic (Lwd.pure x)
 
-  let a_v_alphabetic = pure_arg Svg.a_v_alphabetic
+  let a_v_alphabetic x = Svg.a_v_alphabetic (Lwd.pure x)
 
-  let a_v_mathematical = pure_arg Svg.a_v_mathematical
+  let a_v_mathematical x = Svg.a_v_mathematical (Lwd.pure x)
 
-  let a_v_hanging = pure_arg Svg.a_v_hanging
+  let a_v_hanging x = Svg.a_v_hanging (Lwd.pure x)
 
-  let a_underline_position = pure_arg Svg.a_underline_position
+  let a_underline_position x = Svg.a_underline_position (Lwd.pure x)
 
-  let a_underline_thickness = pure_arg Svg.a_underline_thickness
+  let a_underline_thickness x = Svg.a_underline_thickness (Lwd.pure x)
 
-  let a_strikethrough_position = pure_arg Svg.a_strikethrough_position
+  let a_strikethrough_position x = Svg.a_strikethrough_position (Lwd.pure x)
 
-  let a_strikethrough_thickness =
-    pure_arg Svg.a_strikethrough_thickness
+  let a_strikethrough_thickness x =
+    Svg.a_strikethrough_thickness (Lwd.pure x)
 
-  let a_overline_position = pure_arg Svg.a_overline_position
+  let a_overline_position x = Svg.a_overline_position (Lwd.pure x)
 
-  let a_overline_thickness = pure_arg Svg.a_overline_thickness
+  let a_overline_thickness x = Svg.a_overline_thickness (Lwd.pure x)
 
-  let a_string = pure_arg Svg.a_string
+  let a_string x = Svg.a_string (Lwd.pure x)
 
-  let a_name = pure_arg Svg.a_name
+  let a_name x = Svg.a_name (Lwd.pure x)
 
-  let a_alignment_baseline = pure_arg Svg.a_alignment_baseline
+  let a_alignment_baseline x = Svg.a_alignment_baseline (Lwd.pure x)
 
-  let a_dominant_baseline = pure_arg Svg.a_dominant_baseline
+  let a_dominant_baseline x = Svg.a_dominant_baseline (Lwd.pure x)
 
-  let a_stop_color = pure_arg Svg.a_stop_color
+  let a_stop_color x = Svg.a_stop_color (Lwd.pure x)
 
-  let a_stop_opacity = pure_arg Svg.a_stop_opacity
+  let a_stop_opacity x = Svg.a_stop_opacity (Lwd.pure x)
 
-  let a_stroke = pure_arg Svg.a_stroke
+  let a_stroke x = Svg.a_stroke (Lwd.pure x)
 
-  let a_stroke_width = pure_arg Svg.a_stroke_width
+  let a_stroke_width x = Svg.a_stroke_width (Lwd.pure x)
 
-  let a_stroke_linecap = pure_arg Svg.a_stroke_linecap
+  let a_stroke_linecap x = Svg.a_stroke_linecap (Lwd.pure x)
 
-  let a_stroke_linejoin = pure_arg Svg.a_stroke_linejoin
+  let a_stroke_linejoin x = Svg.a_stroke_linejoin (Lwd.pure x)
 
-  let a_stroke_miterlimit = pure_arg Svg.a_stroke_miterlimit
+  let a_stroke_miterlimit x = Svg.a_stroke_miterlimit (Lwd.pure x)
 
-  let a_stroke_dasharray = pure_arg Svg.a_stroke_dasharray
+  let a_stroke_dasharray x = Svg.a_stroke_dasharray (Lwd.pure x)
 
-  let a_stroke_dashoffset = pure_arg Svg.a_stroke_dashoffset
+  let a_stroke_dashoffset x = Svg.a_stroke_dashoffset (Lwd.pure x)
 
-  let a_stroke_opacity = pure_arg Svg.a_stroke_opacity
+  let a_stroke_opacity x = Svg.a_stroke_opacity (Lwd.pure x)
 
-  let a_onabort = pure_opt_arg Svg.a_onabort
+  let a_onabort x = Svg.a_onabort (Lwd.pure (Some x))
 
-  let a_onactivate = pure_opt_arg Svg.a_onactivate
+  let a_onactivate x = Svg.a_onactivate (Lwd.pure (Some x))
 
-  let a_onbegin = pure_opt_arg Svg.a_onbegin
+  let a_onbegin x = Svg.a_onbegin (Lwd.pure (Some x))
 
-  let a_onend = pure_opt_arg Svg.a_onend
+  let a_onend x = Svg.a_onend (Lwd.pure (Some x))
 
-  let a_onerror = pure_opt_arg Svg.a_onerror
+  let a_onerror x = Svg.a_onerror (Lwd.pure (Some x))
 
-  let a_onfocusin = pure_opt_arg Svg.a_onfocusin
+  let a_onfocusin x = Svg.a_onfocusin (Lwd.pure (Some x))
 
-  let a_onfocusout = pure_opt_arg Svg.a_onfocusout
+  let a_onfocusout x = Svg.a_onfocusout (Lwd.pure (Some x))
 
-  let a_onrepeat = pure_opt_arg Svg.a_onrepeat
+  let a_onrepeat x = Svg.a_onrepeat (Lwd.pure (Some x))
 
-  let a_onresize = pure_opt_arg Svg.a_onresize
+  let a_onresize x = Svg.a_onresize (Lwd.pure (Some x))
 
-  let a_onscroll = pure_opt_arg Svg.a_onscroll
+  let a_onscroll x = Svg.a_onscroll (Lwd.pure (Some x))
 
-  let a_onunload = pure_opt_arg Svg.a_onunload
+  let a_onunload x = Svg.a_onunload (Lwd.pure (Some x))
 
-  let a_onzoom = pure_opt_arg Svg.a_onzoom
+  let a_onzoom x = Svg.a_onzoom (Lwd.pure (Some x))
 
-  let a_onclick = pure_opt_arg Svg.a_onclick
+  let a_onclick x = Svg.a_onclick (Lwd.pure (Some x))
 
-  let a_onmousedown = pure_opt_arg Svg.a_onmousedown
+  let a_onmousedown x = Svg.a_onmousedown (Lwd.pure (Some x))
 
-  let a_onmouseup = pure_opt_arg Svg.a_onmouseup
+  let a_onmouseup x = Svg.a_onmouseup (Lwd.pure (Some x))
 
-  let a_onmouseover = pure_opt_arg Svg.a_onmouseover
+  let a_onmouseover x = Svg.a_onmouseover (Lwd.pure (Some x))
 
-  let a_onmouseout = pure_opt_arg Svg.a_onmouseout
+  let a_onmouseout x = Svg.a_onmouseout (Lwd.pure (Some x))
 
-  let a_onmousemove = pure_opt_arg Svg.a_onmousemove
+  let a_onmousemove x = Svg.a_onmousemove (Lwd.pure (Some x))
 
-  let a_ontouchstart = pure_opt_arg Svg.a_ontouchstart
+  let a_ontouchstart x = Svg.a_ontouchstart (Lwd.pure (Some x))
 
-  let a_ontouchend = pure_opt_arg Svg.a_ontouchend
+  let a_ontouchend x = Svg.a_ontouchend (Lwd.pure (Some x))
 
-  let a_ontouchmove = pure_opt_arg Svg.a_ontouchmove
+  let a_ontouchmove x = Svg.a_ontouchmove (Lwd.pure (Some x))
 
-  let a_ontouchcancel = pure_opt_arg Svg.a_ontouchcancel
+  let a_ontouchcancel x = Svg.a_ontouchcancel (Lwd.pure (Some x))
 
-  let txt = pure_arg Svg.txt
+  let txt x = Svg.txt (Lwd.pure x)
 end
 
 module Pure = struct

--- a/lib/tyxml-lwd/tyxml_lwd.mli
+++ b/lib/tyxml-lwd/tyxml_lwd.mli
@@ -835,7 +835,7 @@ end
 
 open Html_types
 module Pure_html : sig
-  include module type of Html
+  include module type of struct include Html end
   
   val a_class : nmtokens -> [>`Class] attrib
   val a_user_data : string -> string -> [>`User_data] attrib
@@ -1054,7 +1054,7 @@ end
 
 open Svg_types
 module Pure_svg : sig
-  include module type of Svg
+  include module type of struct include Svg end
 
   val a_x : Unit.length -> [>`X] attrib
   val a_y : Unit.length -> [>`Y] attrib

--- a/lib/tyxml-lwd/tyxml_lwd.mli
+++ b/lib/tyxml-lwd/tyxml_lwd.mli
@@ -832,3 +832,500 @@ module Lwdom : sig
   val to_node : _ node -> raw_node
 end
 
+
+open Html_types
+module Pure_html : sig
+  include module type of Html
+  
+  val a_class : nmtokens -> [>`Class] attrib
+  val a_user_data : string -> string -> [>`User_data] attrib
+  val a_id : string -> [>`Id] attrib
+  val a_title : string -> [>`Title] attrib
+  val a_xml_lang : string -> [>`XML_lang] attrib
+  val a_lang : string -> [>`Lang] attrib
+  val a_onabort : (Dom_html.event Js.t -> bool) -> [>`OnAbort] attrib
+  val a_onafterprint : (Dom_html.event Js.t -> bool) -> [>`OnAfterPrint] attrib
+  val a_onbeforeprint : (Dom_html.event Js.t -> bool) -> [>`OnBeforePrint] attrib
+  val a_onbeforeunload : (Dom_html.event Js.t -> bool) -> [>`OnBeforeUnload] attrib
+  val a_onblur : (Dom_html.event Js.t -> bool) -> [>`OnBlur] attrib
+  val a_oncanplay : (Dom_html.event Js.t -> bool) -> [>`OnCanPlay] attrib
+  val a_oncanplaythrough : (Dom_html.event Js.t -> bool) -> [>`OnCanPlayThrough] attrib
+  val a_onchange : (Dom_html.event Js.t -> bool) -> [>`OnChange] attrib
+  val a_ondurationchange : (Dom_html.event Js.t -> bool) -> [>`OnDurationChange] attrib
+  val a_onemptied : (Dom_html.event Js.t -> bool) -> [>`OnEmptied] attrib
+  val a_onended : (Dom_html.event Js.t -> bool) -> [>`OnEnded] attrib
+  val a_onerror : (Dom_html.event Js.t -> bool) -> [>`OnError] attrib
+  val a_onfocus : (Dom_html.event Js.t -> bool) -> [>`OnFocus] attrib
+  val a_onformchange : (Dom_html.event Js.t -> bool) -> [>`OnFormChange] attrib
+  val a_onforminput : (Dom_html.event Js.t -> bool) -> [>`OnFormInput] attrib
+  val a_onhashchange : (Dom_html.event Js.t -> bool) -> [>`OnHashChange] attrib
+  val a_oninput : (Dom_html.event Js.t -> bool) -> [>`OnInput] attrib
+  val a_oninvalid : (Dom_html.event Js.t -> bool) -> [>`OnInvalid] attrib
+  val a_onmousewheel : (Dom_html.event Js.t -> bool) -> [>`OnMouseWheel] attrib
+  val a_onoffline : (Dom_html.event Js.t -> bool) -> [>`OnOffLine] attrib
+  val a_ononline : (Dom_html.event Js.t -> bool) -> [>`OnOnLine] attrib
+  val a_onpause : (Dom_html.event Js.t -> bool) -> [>`OnPause] attrib
+  val a_onplay : (Dom_html.event Js.t -> bool) -> [>`OnPlay] attrib
+  val a_onplaying : (Dom_html.event Js.t -> bool) -> [>`OnPlaying] attrib
+  val a_onpagehide : (Dom_html.event Js.t -> bool) -> [>`OnPageHide] attrib
+  val a_onpageshow : (Dom_html.event Js.t -> bool) -> [>`OnPageShow] attrib
+  val a_onpopstate : (Dom_html.event Js.t -> bool) -> [>`OnPopState] attrib
+  val a_onprogress : (Dom_html.event Js.t -> bool) -> [>`OnProgress] attrib
+  val a_onratechange : (Dom_html.event Js.t -> bool) -> [>`OnRateChange] attrib
+  val a_onreadystatechange : (Dom_html.event Js.t -> bool) -> [>`OnReadyStateChange] attrib
+  val a_onredo : (Dom_html.event Js.t -> bool) -> [>`OnRedo] attrib
+  val a_onresize : (Dom_html.event Js.t -> bool) -> [>`OnResize] attrib
+  val a_onscroll : (Dom_html.event Js.t -> bool) -> [>`OnScroll] attrib
+  val a_onseeked : (Dom_html.event Js.t -> bool) -> [>`OnSeeked] attrib
+  val a_onseeking : (Dom_html.event Js.t -> bool) -> [>`OnSeeking] attrib
+  val a_onselect : (Dom_html.event Js.t -> bool) -> [>`OnSelect] attrib
+  val a_onshow : (Dom_html.event Js.t -> bool) -> [>`OnShow] attrib
+  val a_onstalled : (Dom_html.event Js.t -> bool) -> [>`OnStalled] attrib
+  val a_onstorage : (Dom_html.event Js.t -> bool) -> [>`OnStorage] attrib
+  val a_onsubmit : (Dom_html.event Js.t -> bool) -> [>`OnSubmit] attrib
+  val a_onsuspend : (Dom_html.event Js.t -> bool) -> [>`OnSuspend] attrib
+  val a_ontimeupdate : (Dom_html.event Js.t -> bool) -> [>`OnTimeUpdate] attrib
+  val a_onundo : (Dom_html.event Js.t -> bool) -> [>`OnUndo] attrib
+  val a_onunload : (Dom_html.event Js.t -> bool) -> [>`OnUnload] attrib
+  val a_onvolumechange : (Dom_html.event Js.t -> bool) -> [>`OnVolumeChange] attrib
+  val a_onwaiting : (Dom_html.event Js.t -> bool) -> [>`OnWaiting] attrib
+  val a_onload : (Dom_html.event Js.t -> bool) -> [>`OnLoad] attrib
+  val a_onloadeddata : (Dom_html.event Js.t -> bool) -> [>`OnLoadedData] attrib
+  val a_onloadedmetadata : (Dom_html.event Js.t -> bool) -> [>`OnLoadedMetaData] attrib
+  val a_onloadstart : (Dom_html.event Js.t -> bool) -> [>`OnLoadStart] attrib
+  val a_onmessage : (Dom_html.event Js.t -> bool) -> [>`OnMessage] attrib
+  val a_onclick : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnClick] attrib
+  val a_oncontextmenu : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnContextMenu] attrib
+  val a_ondblclick : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDblClick] attrib
+  val a_ondrag : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDrag] attrib
+  val a_ondragend : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDragEnd] attrib
+  val a_ondragenter : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDragEnter] attrib
+  val a_ondragleave : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDragLeave] attrib
+  val a_ondragover : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDragOver] attrib
+  val a_ondragstart : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDragStart] attrib
+  val a_ondrop : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnDrop] attrib
+  val a_onmousedown : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseDown] attrib
+  val a_onmouseup : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseUp] attrib
+  val a_onmouseover : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseOver] attrib
+  val a_onmousemove : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseMove] attrib
+  val a_onmouseout : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseOut] attrib
+  val a_ontouchstart : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchStart] attrib
+  val a_ontouchend : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchEnd] attrib
+  val a_ontouchmove : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchMove] attrib
+  val a_ontouchcancel : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchCancel] attrib
+  val a_onkeypress : (Dom_html.keyboardEvent Js.t -> bool) -> [>`OnKeyPress] attrib
+  val a_onkeydown : (Dom_html.keyboardEvent Js.t -> bool) -> [>`OnKeyDown] attrib
+  val a_onkeyup : (Dom_html.keyboardEvent Js.t -> bool) -> [>`OnKeyUp] attrib
+  val a_autocomplete : bool -> [>`Autocomplete] attrib
+  val a_crossorigin :
+    [<`Anonymous|`Use_credentials] -> [>`Crossorigin] attrib
+  val a_integrity : string -> [>`Integrity] attrib
+  val a_mediagroup : string -> [>`Mediagroup] attrib
+  val a_challenge : string -> [>`Challenge] attrib
+  val a_contenteditable : bool -> [>`Contenteditable] attrib
+  val a_contextmenu : string -> [>`Contextmenu] attrib
+  val a_dir : [<`Ltr|`Rtl] -> [>`Dir] attrib
+  val a_draggable : bool -> [>`Draggable] attrib
+  val a_form : string -> [>`Form] attrib
+  val a_formaction : Xml.uri -> [>`Formaction] attrib
+  val a_formenctype : string -> [>`Formenctype] attrib
+  val a_formtarget : string -> [>`Formtarget] attrib
+  val a_high : float -> [>`High] attrib
+  val a_icon : Xml.uri -> [>`Icon] attrib
+  val a_keytype : string -> [>`Keytype] attrib
+  val a_list : string -> [>`List] attrib
+  val a_low : float -> [>`High] attrib
+  val a_max : float -> [>`Max] attrib
+  val a_input_max : number_or_datetime -> [>`Input_Max] attrib
+  val a_min : float -> [>`Min] attrib
+  val a_input_min : number_or_datetime -> [>`Input_Min] attrib
+  val a_inputmode :
+    [<`Email|`Full_width_latin|`Kana|`Katakana|`Latin
+    |`Latin_name|`Latin_prose|`Numeric|`Tel|`Url|`Verbatim] ->
+    [>`Inputmode] attrib
+  val a_optimum : float -> [>`Optimum] attrib
+  val a_pattern : string -> [>`Pattern] attrib
+  val a_placeholder : string -> [>`Placeholder] attrib
+  val a_poster : Xml.uri -> [>`Poster] attrib
+  val a_preload : [<`Audio|`Metadata|`None] -> [>`Preload] attrib
+  val a_radiogroup : string -> [>`Radiogroup] attrib
+  val a_referrerpolicy : referrerpolicy -> [>`Referrerpolicy] attrib
+  val a_sandbox : [<sandbox_token] list -> [>`Sandbox] attrib
+  val a_spellcheck : bool -> [>`Spellcheck] attrib
+  val a_sizes : (int * int) list option -> [>`Sizes] attrib
+  val a_span : int -> [>`Span] attrib
+  val a_srcset : image_candidate list -> [>`Srcset] attrib
+  val a_img_sizes : string list -> [>`Img_sizes] attrib
+  val a_start : int -> [>`Start] attrib
+  val a_step : float option -> [>`Step] attrib
+  val a_wrap : [<`Hard | `Soft] -> [>`Wrap] attrib
+  val a_version : string -> [>`Version] attrib
+  val a_xmlns : [<`W3_org_1999_xhtml] -> [>`XMLns] attrib
+  val a_manifest : Xml.uri -> [>`Manifest] attrib
+  val a_cite : Xml.uri -> [>`Cite] attrib
+  val a_xml_space : [<`Default | `Preserve] -> [>`XML_space] attrib
+  val a_accesskey : char -> [>`Accesskey] attrib
+  val a_charset : string -> [>`Charset] attrib
+  val a_accept_charset : charsets -> [>`Accept_charset] attrib
+  val a_accept : contenttypes -> [>`Accept] attrib
+  val a_href : Xml.uri -> [>`Href] attrib
+  val a_hreflang : string -> [>`Hreflang] attrib
+  val a_download : string option -> [>`Download] attrib
+  val a_rel : linktypes -> [>`Rel] attrib
+  val a_tabindex : int -> [>`Tabindex] attrib
+  val a_mime_type : string -> [>`Mime_type] attrib
+  val a_datetime : string -> [>`Datetime] attrib
+  val a_action : Xml.uri -> [>`Action] attrib
+  val a_cols : int -> [>`Cols] attrib
+  val a_enctype : string -> [>`Enctype] attrib
+  val a_label_for : string -> [>`Label_for] attrib
+  val a_output_for : idrefs -> [>`Output_for] attrib
+  val a_maxlength : int -> [>`Maxlength] attrib
+  val a_minlength : int -> [>`Minlength] attrib
+  val a_method : [<`Get | `Post] -> [>`Method] attrib
+  val a_name : string -> [>`Name] attrib
+  val a_rows : int -> [>`Rows] attrib
+  val a_size : int -> [>`Size] attrib
+  val a_src : Xml.uri -> [>`Src] attrib
+  val a_input_type :
+    [<`Button|`Checkbox|`Color|`Date|`Datetime|`Datetime_local|`Email|`File
+    |`Hidden|`Image|`Month|`Number|`Password|`Radio|`Range|`Reset|`Search
+    |`Submit|`Tel|`Text|`Time|`Url|`Week] ->
+    [>`Input_Type] attrib
+  val a_text_value : string -> [>`Text_Value] attrib
+  val a_int_value : int -> [>`Int_Value] attrib
+  val a_value : string -> [>`Value] attrib
+  val a_float_value : float -> [>`Float_Value] attrib
+  val a_button_type : [<`Button|`Reset|`Submit] -> [>`Button_Type] attrib
+  val a_command_type : [<`Checkbox|`Command|`Radio] -> [>`Command_Type] attrib
+  val a_menu_type : [<`Context|`Toolbar] -> [>`Menu_Type] attrib
+  val a_label : string -> [>`Label] attrib
+  val a_colspan : int -> [>`Colspan] attrib
+  val a_headers : idrefs -> [>`Headers] attrib
+  val a_rowspan : int -> [>`Rowspan] attrib
+  val a_alt : string -> [>`Alt] attrib
+  val a_height : int -> [>`Height] attrib
+  val a_width : int -> [>`Width] attrib
+  val a_shape : shape -> [>`Shape] attrib
+  val a_coords : numbers -> [>`Coords] attrib
+  val a_usemap : string -> [>`Usemap] attrib
+  val a_data : Xml.uri -> [>`Data] attrib
+  val a_scrolling : [<`Auto | `No | `Yes] -> [>`Scrolling] attrib
+  val a_target : string -> [>`Target] attrib
+  val a_content : string -> [>`Content] attrib
+  val a_http_equiv : string -> [>`Http_equiv] attrib
+  val a_media : mediadesc -> [>`Media] attrib
+  val a_style : string -> [>`Style_Attr] attrib
+  val a_property : string -> [>`Property] attrib
+  val a_role : string list -> [>`Role] attrib
+  val a_aria : string -> string list -> [>`Aria] attrib
+  
+  val txt : string -> [>txt] elt
+  val bdo : dir:[<`Ltr | `Rtl] ->
+    ([<bdo_attrib], [<bdo_content_fun], [>bdo]) star
+  val img : src:Xml.uri -> alt:string ->
+    ([<img_attrib], [>img]) nullary
+  val audio : ?src:Xml.uri -> ?srcs:[<source] elt list ->
+    ([<audio_attrib], 'a, [>'a audio]) star
+  val video : ?src:Xml.uri -> ?srcs:[<source] elt list ->
+    ([<video_attrib], 'a, [>'a video]) star
+  val area : alt:string ->
+    ([<`Accesskey|`Alt|`Aria|`Class|`Contenteditable|`Contextmenu|`Coords
+     |`Dir|`Draggable|`Hidden|`Hreflang|`Id|`Lang |`Media|`Mime_type
+     |`OnAbort|`OnBlur|`OnCanPlay|`OnCanPlayThrough|`OnChange|`OnClick
+     |`OnContextMenu|`OnDblClick|`OnDrag|`OnDragEnd|`OnDragEnter
+     |`OnDragLeave|`OnDragOver|`OnDragStart|`OnDrop|`OnDurationChange
+     |`OnEmptied|`OnEnded|`OnError|`OnFocus|`OnFormChange|`OnFormInput
+     |`OnInput|`OnInvalid|`OnKeyDown|`OnKeyPress|`OnKeyUp|`OnLoad
+     |`OnLoadStart|`OnLoadedData|`OnLoadedMetaData|`OnMouseDown
+     |`OnMouseMove|`OnMouseOut|`OnMouseOver|`OnMouseUp|`OnMouseWheel
+     |`OnPause|`OnPlay|`OnPlaying|`OnProgress|`OnRateChange
+     |`OnReadyStateChange|`OnScroll|`OnSeeked|`OnSeeking|`OnSelect
+     |`OnShow|`OnStalled|`OnSubmit|`OnSuspend|`OnTimeUpdate|`OnTouchCancel
+     |`OnTouchEnd|`OnTouchMove|`OnTouchStart|`OnVolumeChange|`OnWaiting
+     |`Rel|`Role|`Shape|`Spellcheck|`Style_Attr|`Tabindex|`Target
+     |`Title|`User_data|`XML_lang|`XMLns], [>area]) nullary
+  val optgroup : label:string ->
+    ([<optgroup_attrib], [<optgroup_content_fun], [>optgroup]) star
+  val command : label:string -> ([<command_attrib], [>command]) nullary
+  val link : rel:linktypes -> href:Xml.uri ->
+    ([<link_attrib], [>link]) nullary
+end
+
+open Svg_types
+module Pure_svg : sig
+  include module type of Svg
+
+  val a_x : Unit.length -> [>`X] attrib
+  val a_y : Unit.length -> [>`Y] attrib
+  val a_width : Unit.length -> [>`Width] attrib
+  val a_height : Unit.length -> [>`Height] attrib
+  val a_preserveAspectRatio : uri -> [>`PreserveAspectRatio] attrib
+  val a_zoomAndPan : [<`Disable|`Magnify] -> [>`ZoomAndSpan] attrib
+  val a_href : uri -> [>`Xlink_href] attrib
+  val a_requiredExtensions : spacestrings -> [>`RequiredExtension] attrib
+  val a_systemLanguage :
+    commastrings -> [>`SystemLanguage] attrib
+  val a_externalRessourcesRequired :
+    bool -> [>`ExternalRessourcesRequired] attrib
+  val a_id : uri -> [>`Id] attrib
+  val a_user_data : uri -> uri -> [>`User_data] attrib
+  val a_xml_lang : uri -> [>`Xml_Lang] attrib
+  val a_type : uri -> [>`Type] attrib
+  val a_media : commastrings -> [>`Media] attrib
+  val a_class : spacestrings -> [>`Class] attrib
+  val a_style : uri -> [>`Style] attrib
+  val a_transform : transforms -> [>`Transform] attrib
+  val a_viewBox : fourfloats -> [>`ViewBox] attrib
+  val a_d : uri -> [>`D] attrib
+  val a_pathLength : float -> [>`PathLength] attrib
+  val a_rx : Unit.length -> [>`Rx] attrib
+  val a_ry : Unit.length -> [>`Ry] attrib
+  val a_cx : Unit.length -> [>`Cx] attrib
+  val a_cy : Unit.length -> [>`Cy] attrib
+  val a_r : Unit.length -> [>`R] attrib
+  val a_x1 : Unit.length -> [>`X1] attrib
+  val a_y1 : Unit.length -> [>`Y1] attrib
+  val a_x2 : Unit.length -> [>`X2] attrib
+  val a_y2 : Unit.length -> [>`Y2] attrib
+  val a_points : coords -> [>`Points] attrib
+  val a_x_list : lengths -> [>`X_list] attrib
+  val a_y_list : lengths -> [>`Y_list] attrib
+  val a_dx : float -> [>`Dx] attrib
+  val a_dy : float -> [>`Dy] attrib
+  val a_dx_list : lengths -> [>`Dx_list] attrib
+  val a_dy_list : lengths -> [>`Dy_list] attrib
+  val a_lengthAdjust :
+    [<`Spacing|`SpacingAndGlyphs] -> [>`LengthAdjust] attrib
+  val a_textLength : Unit.length -> [>`TextLength] attrib
+  val a_text_anchor :
+    [<`End|`Inherit|`Middle|`Start] -> [>`Text_Anchor] attrib
+  val a_text_decoration :
+    [<`Blink|`Inherit|`Line_through|`None|`Overline|`Underline] ->
+    [>`Text_Decoration] attrib
+  val a_text_rendering :
+    [<`Auto|`GeometricPrecision|`Inherit
+    |`OptimizeLegibility|`OptimizeSpeed] ->
+    [>`Text_Rendering] attrib
+  val a_rotate : numbers -> [>`Rotate] attrib
+  val a_startOffset : Unit.length -> [>`StartOffset] attrib
+  val a_method : [<`Align | `Stretch] -> [>`Method] attrib
+  val a_spacing : [<`Auto | `Exact] -> [>`Spacing] attrib
+  val a_glyphRef : uri -> [>`GlyphRef] attrib
+  val a_format : uri -> [>`Format] attrib
+  val a_markerUnits :
+    [<`StrokeWidth | `UserSpaceOnUse] -> [>`MarkerUnits] attrib
+  val a_refX : Unit.length -> [>`RefX] attrib
+  val a_refY : Unit.length -> [>`RefY] attrib
+  val a_markerWidth : Unit.length -> [>`MarkerWidth] attrib
+  val a_markerHeight :
+    Unit.length -> [>`MarkerHeight] attrib
+  val a_orient : Unit.angle option -> [>`Orient] attrib
+  val a_local : uri -> [>`Local] attrib
+  val a_rendering_intent :
+    [<`Absolute_colorimetric|`Auto|`Perceptual
+    |`Relative_colorimetric|`Saturation] ->
+    [>`Rendering_Indent] attrib
+  val a_gradientUnits :
+    [<`ObjectBoundingBox|`UserSpaceOnUse] -> [`GradientUnits] attrib
+  val a_gradientTransform : transforms -> [>`Gradient_Transform] attrib
+  val a_spreadMethod : [<`Pad|`Reflect|`Repeat] -> [>`SpreadMethod] attrib
+  val a_fx : Unit.length -> [>`Fx] attrib
+  val a_fy : Unit.length -> [>`Fy] attrib
+  val a_offset : [<`Number of float | `Percentage of float] ->
+    [>`Offset] attrib
+  val a_patternUnits : [<`ObjectBoundingBox|`UserSpaceOnUse] ->
+    [>`PatternUnits] attrib
+  val a_patternContentUnits : [<`ObjectBoundingBox|`UserSpaceOnUse] ->
+    [>`PatternContentUnits] attrib
+  val a_patternTransform : transforms -> [>`PatternTransform] attrib
+  val a_clipPathUnits : [<`ObjectBoundingBox|`UserSpaceOnUse] ->
+    [>`ClipPathUnits] attrib
+  val a_maskUnits : [<`ObjectBoundingBox|`UserSpaceOnUse] ->
+    [>`MaskUnits] attrib
+  val a_maskContentUnits : [<`ObjectBoundingBox|`UserSpaceOnUse] ->
+    [>`MaskContentUnits] attrib
+  val a_primitiveUnits : [<`ObjectBoundingBox|`UserSpaceOnUse] ->
+    [>`PrimitiveUnits] attrib
+  val a_filterRes : number_optional_number -> [>`FilterResUnits] attrib
+  val a_result : uri -> [>`Result] attrib
+  val a_in :
+    [<`BackgroundAlpha|`BackgroundImage|`FillPaint|`Ref of uri
+    |`SourceAlpha|`SourceGraphic|`StrokePaint] -> [>`In] attrib
+  val a_in2 :
+    [<`BackgroundAlpha|`BackgroundImage|`FillPaint|`Ref of uri
+    |`SourceAlpha|`SourceGraphic|`StrokePaint] -> [>`In2] attrib
+  val a_azimuth : float -> [>`Azimuth] attrib
+  val a_elevation : float -> [>`Elevation] attrib
+  val a_pointsAtX : float -> [>`PointsAtX] attrib
+  val a_pointsAtY : float -> [>`PointsAtY] attrib
+  val a_pointsAtZ : float -> [>`PointsAtZ] attrib
+  val a_specularExponent : float -> [>`SpecularExponent] attrib
+  val a_specularConstant : float -> [>`SpecularConstant] attrib
+  val a_limitingConeAngle : float -> [>`LimitingConeAngle] attrib
+  val a_mode :
+    [<`Darken|`Lighten|`Multiply|`Normal|`Screen] -> [>`Mode] attrib
+  val a_feColorMatrix_type :
+    [<`HueRotate|`LuminanceToAlpha|`Matrix|`Saturate] ->
+    [>`Typefecolor] attrib
+  val a_values : numbers -> [>`Values] attrib
+  val a_transfer_type : [<`Discrete|`Gamma|`Identity|`Linear|`Table] ->
+    [>`Type_transfert] attrib
+  val a_tableValues : numbers -> [>`TableValues] attrib
+  val a_intercept : float -> [>`Intercept] attrib
+  val a_amplitude : float -> [>`Amplitude] attrib
+  val a_exponent : float -> [>`Exponent] attrib
+  val a_transfer_offset : float -> [>`Offset_transfer] attrib
+  val a_feComposite_operator : [<`Arithmetic|`Atop|`In|`Out|`Over|`Xor] ->
+    [>`OperatorComposite] attrib
+  val a_k1 : float -> [>`K1] attrib
+  val a_k2 : float -> [>`K2] attrib
+  val a_k3 : float -> [>`K3] attrib
+  val a_k4 : float -> [>`K4] attrib
+  val a_order : number_optional_number -> [>`Order] attrib
+  val a_kernelMatrix : numbers -> [>`KernelMatrix] attrib
+  val a_divisor : float -> [>`Divisor] attrib
+  val a_bias : float -> [>`Bias] attrib
+  val a_kernelUnitLength :
+    number_optional_number -> [>`KernelUnitLength] attrib
+  val a_targetX : int -> [>`TargetX] attrib
+  val a_targetY : int -> [>`TargetY] attrib
+  val a_edgeMode : [<`Duplicate|`None|`Wrap] -> [>`TargetY] attrib
+  val a_preserveAlpha : bool -> [>`TargetY] attrib
+  val a_surfaceScale : float -> [>`SurfaceScale] attrib
+  val a_diffuseConstant : float -> [>`DiffuseConstant] attrib
+  val a_scale : float -> [>`Scale] attrib
+  val a_xChannelSelector : [<`A|`B|`G|`R] -> [>`XChannelSelector] attrib
+  val a_yChannelSelector : [<`A|`B|`G|`R] -> [>`YChannelSelector] attrib
+  val a_stdDeviation : number_optional_number -> [>`StdDeviation] attrib
+  val a_feMorphology_operator : [<`Dilate|`Erode] -> [>`OperatorMorphology] attrib
+  val a_radius : number_optional_number -> [>`Radius] attrib
+  val a_baseFrenquency : number_optional_number -> [>`BaseFrequency] attrib
+  val a_numOctaves : int -> [>`NumOctaves] attrib
+  val a_seed : float -> [>`Seed] attrib
+  val a_stitchTiles : [<`NoStitch|`Stitch] -> [>`StitchTiles] attrib
+  val a_feTurbulence_type : [<`FractalNoise|`Turbulence] -> [>`TypeStitch] attrib
+  val a_target : uri -> [>`Xlink_target] attrib
+  val a_attributeName : uri -> [>`AttributeName] attrib
+  val a_attributeType : [<`Auto|`CSS|`XML] -> [>`AttributeType] attrib
+  val a_begin : uri -> [>`Begin] attrib
+  val a_dur : uri -> [>`Dur] attrib
+  val a_min : uri -> [>`Min] attrib
+  val a_max : uri -> [>`Max] attrib
+  val a_restart : [<`Always|`Never|`WhenNotActive] -> [>`Restart] attrib
+  val a_repeatCount : uri -> [>`RepeatCount] attrib
+  val a_repeatDur : uri -> [>`RepeatDur] attrib
+  val a_fill : paint -> [>`Fill] attrib
+  val a_animation_fill : [<`Freeze|`Remove] -> [>`Fill_Animation] attrib
+  val a_calcMode : [<`Discrete|`Linear|`Paced|`Spline] -> [>`CalcMode] attrib
+  val a_animation_values : strings -> [>`Valuesanim] attrib
+  val a_keyTimes : strings -> [>`KeyTimes] attrib
+  val a_keySplines : strings -> [>`KeySplines] attrib
+  val a_from : uri -> [>`From] attrib
+  val a_to : uri -> [>`To] attrib
+  val a_by : uri -> [>`By] attrib
+  val a_additive : [<`Replace|`Sum] -> [>`Additive] attrib
+  val a_accumulate : [<`None|`Sum] -> [>`Accumulate] attrib
+  val a_keyPoints : numbers_semicolon -> [>`KeyPoints] attrib
+  val a_path : uri -> [>`Path] attrib
+  val a_animateTransform_type :
+    [`Rotate|`Scale|`SkewX|`SkewY|`Translate] ->
+    [`Typeanimatetransform] attrib
+  val a_horiz_origin_x : float -> [>`HorizOriginX] attrib
+  val a_horiz_origin_y : float -> [>`HorizOriginY] attrib
+  val a_horiz_adv_x : float -> [>`HorizAdvX] attrib
+  val a_vert_origin_x : float -> [>`VertOriginX] attrib
+  val a_vert_origin_y : float -> [>`VertOriginY] attrib
+  val a_vert_adv_y : float -> [>`VertAdvY] attrib
+  val a_unicode : uri -> [>`Unicode] attrib
+  val a_glyph_name : uri -> [>`glyphname] attrib
+  val a_orientation : [<`H | `V] -> [>`Orientation] attrib
+  val a_arabic_form : [<`Initial|`Isolated|`Medial|`Terminal] ->
+    [>`Arabicform] attrib
+  val a_lang : uri -> [>`Lang] attrib
+  val a_u1 : uri -> [>`U1] attrib
+  val a_u2 : uri -> [>`U2] attrib
+  val a_g1 : uri -> [>`G1] attrib
+  val a_g2 : uri -> [>`G2] attrib
+  val a_k : uri -> [>`K] attrib
+  val a_font_family : uri -> [>`Font_Family] attrib
+  val a_font_style : uri -> [>`Font_Style] attrib
+  val a_font_variant : uri -> [>`Font_Variant] attrib
+  val a_font_weight : uri -> [>`Font_Weight] attrib
+  val a_font_stretch : uri -> [>`Font_Stretch] attrib
+  val a_font_size : uri -> [>`Font_Size] attrib
+  val a_unicode_range : uri -> [>`UnicodeRange] attrib
+  val a_units_per_em : uri -> [>`UnitsPerEm] attrib
+  val a_stemv : float -> [>`Stemv] attrib
+  val a_stemh : float -> [>`Stemh] attrib
+  val a_slope : float -> [>`Slope] attrib
+  val a_cap_height : float -> [>`CapHeight] attrib
+  val a_x_height : float -> [>`XHeight] attrib
+  val a_accent_height : float -> [>`AccentHeight] attrib
+  val a_ascent : float -> [>`Ascent] attrib
+  val a_widths : uri -> [>`Widths] attrib
+  val a_bbox : uri -> [>`Bbox] attrib
+  val a_ideographic : float -> [>`Ideographic] attrib
+  val a_alphabetic : float -> [>`Alphabetic] attrib
+  val a_mathematical : float -> [>`Mathematical] attrib
+  val a_hanging : float -> [>`Hanging] attrib
+  val a_videographic : float -> [>`VIdeographic] attrib
+  val a_v_alphabetic : float -> [>`VAlphabetic] attrib
+  val a_v_mathematical : float -> [>`VMathematical] attrib
+  val a_v_hanging : float -> [>`VHanging] attrib
+  val a_underline_position : float -> [>`UnderlinePosition] attrib
+  val a_underline_thickness : float -> [>`UnderlineThickness] attrib
+  val a_strikethrough_position : float -> [>`StrikethroughPosition] attrib
+  val a_strikethrough_thickness : float -> [>`StrikethroughThickness] attrib
+  val a_overline_position : float -> [>`OverlinePosition] attrib
+  val a_overline_thickness : float -> [>`OverlineThickness] attrib
+  val a_string : uri -> [>`String] attrib
+  val a_name : uri -> [>`Name] attrib
+  val a_alignment_baseline :
+    [<`After_edge|`Alphabetic|`Auto|`Baseline|`Before_edge|`Central|`Hanging
+    |`Ideographic|`Inherit|`Mathematical|`Middle
+    |`Text_after_edge|`Text_before_edge] -> [>`Alignment_Baseline] attrib
+  val a_dominant_baseline :
+    [<`Alphabetic|`Auto|`Central|`Hanging|`Ideographic|`Inherit
+    |`Mathematical|`Middle|`No_change|`Reset_size|`Text_after_edge
+    |`Text_before_edge|`Use_script] -> [>`Dominant_Baseline] attrib
+  val a_stop_color : uri -> [>`Stop_Color] attrib
+  val a_stop_opacity : float -> [>`Stop_Opacity] attrib
+  val a_stroke : paint -> [>`Stroke] attrib
+  val a_stroke_width : Unit.length -> [>`Stroke_Width] attrib
+  val a_stroke_linecap : [<`Butt|`Round|`Square] -> [>`Stroke_Linecap] attrib
+  val a_stroke_linejoin : [<`Bever|`Miter|`Round] -> [>`Stroke_Linejoin] attrib
+  val a_stroke_miterlimit : float -> [>`Stroke_Miterlimit] attrib
+  val a_stroke_dasharray : Unit.length list -> [>`Stroke_Dasharray] attrib
+  val a_stroke_dashoffset : Unit.length -> [>`Stroke_Dashoffset] attrib
+  val a_stroke_opacity : float -> [>`Stroke_Opacity] attrib
+  val a_onabort : (Dom_html.event Js.t -> bool) -> [>`OnAbort] attrib
+  val a_onactivate : (Dom_html.event Js.t -> bool) -> [>`OnActivate] attrib
+  val a_onbegin : (Dom_html.event Js.t -> bool) -> [>`OnBegin] attrib
+  val a_onend : (Dom_html.event Js.t -> bool) -> [>`OnEnd] attrib
+  val a_onerror : (Dom_html.event Js.t -> bool) -> [>`OnError] attrib
+  val a_onfocusin : (Dom_html.event Js.t -> bool) -> [>`OnFocusIn] attrib
+  val a_onfocusout : (Dom_html.event Js.t -> bool) -> [>`OnFocusOut] attrib
+  val a_onrepeat : (Dom_html.event Js.t -> bool) -> [>`OnRepeat] attrib
+  val a_onresize : (Dom_html.event Js.t -> bool) -> [>`OnResize] attrib
+  val a_onscroll : (Dom_html.event Js.t -> bool) -> [>`OnScroll] attrib
+  val a_onunload : (Dom_html.event Js.t -> bool) -> [>`OnUnload] attrib
+  val a_onzoom : (Dom_html.event Js.t -> bool) -> [>`OnZoom] attrib
+  val a_onclick : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnClick] attrib
+  val a_onmousedown : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseDown] attrib
+  val a_onmouseup : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseUp] attrib
+  val a_onmouseover : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseOver] attrib
+  val a_onmouseout : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseOut] attrib
+  val a_onmousemove : (Dom_html.mouseEvent Js.t -> bool) -> [>`OnMouseMove] attrib
+  val a_ontouchstart : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchStart] attrib
+  val a_ontouchend : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchEnd] attrib
+  val a_ontouchmove : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchMove] attrib
+  val a_ontouchcancel : (Dom_html.touchEvent Js.t -> bool) -> [>`OnTouchCancel] attrib
+
+  val txt : uri -> [>txt] elt
+end
+
+module Pure : sig
+  module Svg = Pure_svg
+  module Html = Pure_html
+end


### PR DESCRIPTION
Being able to use `Lwd.t` for every Tyxml_lwd element's parameter is awesome, but when writing large documents, that's a lot of `Lwd.pure`.

This PR adds two modules in `Tyxml_lwd`: `Pure.Html`, and `Pure.Svg` that are counterparts of the `Html` and `Svg` modules, but which functions take pure arguments and convert them to `Lwd.t`.

This allows to re-use "normal" Tyxml code with `Lwd`.