### PR TITLE
Labelled interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(RUN_TESTS_BC):
 	dune exec examples/$(patsubst run-%,%,$@.bc)
 
 $(RUN_TESTS_EXE):
-	dune exec examples/$(patsubst run-%,%,$@.exe)
+	dune exec examples/$(patsubst run-%,%,$@)
 
 run-cbor-explorer.exe:
 	rm curdir.cbor || true

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,19 @@
+- Document implementation
+- Switch to labelled interface
+- Make "window manager" a core Nottui concept:
+  - applications start by creating a window manager
+  - main loop runs a window manager and not a ui Lwd.t
+  - main loop quit when there is no window scheduled
+- Benchmark "compact" trace representation:
+  It should consume a bit less memory (that should be observable in misc
+  example with a million edit fields) and should not affect runtime
+  performance... However it seems to do so (in misc and stress),
+  especially in bytecode, maybe because of the additional recursive functions.
+- Add a standard mainloop / update scheduler to Tyxml-lwd:
+  - it should take into account different roots 
+    (multiple sub-trees of the DOM that are maintained by lwd)
+  - it should support "unstable" documents (those that need more than one
+    update cycle):
+    - provide different levels of logging for profiling unstable parts?
+    - maybe split update cycles in different chunks, so that we can still
+      produce a frame within time budget when a fixpoint cannot be reached

--- a/examples/cbor/cbor_explorer.ml
+++ b/examples/cbor/cbor_explorer.ml
@@ -57,7 +57,7 @@ let ui_of_cbor (c:C.t) =
     in
     W.unfoldable summary (fun () -> traverse ~fold:false y)
   in
-  let w = Lwd.map2 Ui.Ui.join_y
+  let w = Lwd.map2 ~f:Ui.Ui.join_y
       w_q (Nottui_widgets.scroll_area @@ traverse ~fold:true c)
   in
   quit, w

--- a/examples/minesweeper/main.ml
+++ b/examples/minesweeper/main.ml
@@ -21,7 +21,7 @@ let event_input event =
   | Some target -> Some (Js.to_string target##.value)
 
 let int_input name value ~set_value =
-  let value = Lwd.map string_of_int value in
+  let value = Lwd.map ~f:string_of_int value in
   children [
     Html.txt (Lwd.pure name);
     Html.input ~a:[

--- a/examples/minesweeper/minesweeper.ml
+++ b/examples/minesweeper/minesweeper.ml
@@ -168,7 +168,7 @@ let cell_image_src cell =
 
 let cell_image cell ~on_click =
   Html.img
-    ~src:(Lwd.map cell_image_src cell)
+    ~src:(Lwd.map ~f:cell_image_src cell)
     ~alt:(Lwd.pure "Hello")
     ~a:[Html.a_onclick (Lwdom.attr (fun _ -> on_click ()))]
     ()

--- a/examples/minimal.ml
+++ b/examples/minimal.ml
@@ -38,9 +38,9 @@ let degrees = Lwd.var 0.0
 let farenheit = Lwd.var (nan, ("", 0))
 
 let farenheit_text =
-  Lwd.map2' (Lwd.get degrees) (Lwd.get farenheit)
-    (fun d (d', f) ->
-       if d = d' then f else (string_of_float (c_to_f d), 0))
+  Lwd.map2 (Lwd.get degrees) (Lwd.get farenheit)
+    ~f:(fun d (d', f) ->
+        if d = d' then f else (string_of_float (c_to_f d), 0))
 
 let farenheit_edit =
   Nottui_widgets.edit_field
@@ -57,8 +57,8 @@ let farenheit_edit =
 let celsius = Lwd.var (nan, ("", 0))
 
 let celsius_text =
-  Lwd.map2' (Lwd.get degrees) (Lwd.get celsius)
-    (fun d (d', f) -> if d = d' then f else (string_of_float d, 0))
+  Lwd.map2 (Lwd.get degrees) (Lwd.get celsius)
+    ~f:(fun d (d', f) -> if d = d' then f else (string_of_float d, 0))
 
 let celsius_edit =
   Nottui_widgets.edit_field

--- a/examples/pretty.ml
+++ b/examples/pretty.ml
@@ -6,11 +6,14 @@ let string ?attr text = P.ui (Nottui_widgets.string ?attr text)
 let (^^) = P.(^^)
 let (^/^) a b = P.(a ^^ break 1 ^^ b)
 
+let base = Lwd.var Nottui_widgets.empty_lwd
+
+let wm = Nottui_widgets.window_manager (Lwd.join (Lwd.get base))
 
 let spring = P.ui (Ui.resize ~sw:1 Ui.empty)
 
 let selector text f choices =
-  Nottui_widgets.main_menu_item text (fun () ->
+  Nottui_widgets.main_menu_item wm text (fun () ->
       Lwd.pure @@ Ui.vcat (
         List.map
           (fun choice ->
@@ -68,8 +71,9 @@ let doc =
 let contents width = Lwd.map2' width doc P.pretty
 
 let () =
-  Ui_loop.run (
+  Lwd.set base (
     Nottui_widgets.h_pane
       (Nottui_widgets.scroll_area (varying_width contents))
       (Lwd.pure Ui.empty)
-  )
+  );
+  Ui_loop.run (Nottui_widgets.window_manager_view wm)

--- a/examples/pretty.ml
+++ b/examples/pretty.ml
@@ -26,9 +26,8 @@ let fruit =
   let fruits = ["Apple"; "Orange"; "Strawberry"] in
   let choice = Lwd.var (List.hd fruits) in
   Lwd.join (
-    Lwd.map' (Lwd.get choice) (fun current ->
-        selector current (Lwd.set choice) fruits
-      )
+    Lwd.map (Lwd.get choice)
+      ~f:(fun current -> selector current (Lwd.set choice) fruits)
   )
 
 let doc = Lwd_table.make ()
@@ -48,7 +47,7 @@ let () =
         P.hardline; P.ui (Ui.space 0 1); P.hardline;
       ];
     Lwd_table.append' doc
-      (Lwd.map' fruit (fun fruit ->
+      (Lwd.map fruit ~f:(fun fruit ->
            P.group (spring ^^ string "I" ^^ spring ^/^
                     P.group (string "like" ^^ spring ^/^
                              P.ui fruit ^^ spring ^/^
@@ -58,17 +57,16 @@ let () =
 
 let varying_width f =
   let width = Lwd.var 0 in
-  Lwd.map'
-    (f (Lwd.get width))
-    (fun ui ->
-       Ui.size_sensor
-         (fun ~w ~h:_ -> if Lwd.peek width <> w then Lwd.set width w)
-         (Ui.resize ~sw:1 ~sh:1 ~w:0 ui))
+  Lwd.map (f (Lwd.get width)) ~f:(fun ui ->
+      Ui.size_sensor
+        (fun ~w ~h:_ -> if Lwd.peek width <> w then Lwd.set width w)
+        (Ui.resize ~sw:1 ~sh:1 ~w:0 ui)
+    )
 
 let doc =
   Lwd.join (Lwd_table.reduce (Lwd_utils.lift_monoid (P.empty, P.(^^))) doc)
 
-let contents width = Lwd.map2' width doc P.pretty
+let contents width = Lwd.map2 ~f:P.pretty width doc
 
 let () =
   Lwd.set base (

--- a/examples/reranger.ml
+++ b/examples/reranger.ml
@@ -21,8 +21,6 @@ let remember_width ~wref ui =
   wref := max (Ui.layout_spec ui).Ui.w !wref;
   Ui.resize ~w:!wref ui
 
-let menu_quit = main_menu_item "Quit" (fun () -> exit 0)
-
 let rec dir ?(initial_path = []) ?after_width:(wref = ref 0) path =
   let column = Lwd.var (Lwd.return Ui.empty) in
   let header = string ~attr:Notty.(A.bg A.green) (Filename.basename path) in
@@ -132,9 +130,13 @@ let () =
     in
     List.rev (split (Sys.getcwd ()))
   in
-  let ui =
-    Lwd_utils.pack Ui.pack_y [ menu_quit; dir ~initial_path "/"]
+  let body = Lwd.var (Lwd.pure Ui.empty) in
+  let wm = Nottui_widgets.window_manager (Lwd.join (Lwd.get body)) in
+  let ui = Lwd_utils.pack Ui.pack_y [
+      main_menu_item wm "Quit" (fun () -> exit 0);
+      dir ~initial_path "/"
+    ]
   in
-  Ui_loop.run
-    (Lwd.map' ui (fun ui ->
-         ui |> Ui.resize ~pad:gravity_pad ~crop:gravity_crop))
+  Lwd.set body (Lwd.map (Ui.resize ~pad:gravity_pad ~crop:gravity_crop) ui);
+  Ui_loop.run (Nottui_widgets.window_manager_view wm)
+

--- a/examples/reranger.ml
+++ b/examples/reranger.ml
@@ -47,8 +47,8 @@ let rec dir ?(initial_path = []) ?after_width:(wref = ref 0) path =
     in
     let t = Lwd_utils.pack Ui.pack_y [ Lwd.return header; body ] in
     let t =
-      if constrain then Lwd.map (Ui.resize ~w:12) t
-      else Lwd.map (remember_width ~wref) t
+      if constrain then Lwd.map ~f:(Ui.resize ~w:12) t
+      else Lwd.map ~f:(remember_width ~wref) t
     in
     column $= Lwd_utils.pack Ui.pack_x [ t; Lwd.join (Lwd.get after) ]
   in
@@ -61,7 +61,7 @@ let rec dir ?(initial_path = []) ?after_width:(wref = ref 0) path =
       with exn ->
         Lwd.return (string ~attr:Notty.(A.bg A.red) (Printexc.to_string exn))
     in
-    after $= Lwd.map (Ui.join_x (string " ")) t
+    after $= Lwd.map ~f:(Ui.join_x (string " ")) t
   in
   let highlighted_cell = ref None in
   let rec render_directory ?(highlight = false) cell name =
@@ -137,6 +137,6 @@ let () =
       dir ~initial_path "/"
     ]
   in
-  Lwd.set body (Lwd.map (Ui.resize ~pad:gravity_pad ~crop:gravity_crop) ui);
+  Lwd.set body (Lwd.map ~f:(Ui.resize ~pad:gravity_pad ~crop:gravity_crop) ui);
   Ui_loop.run (Nottui_widgets.window_manager_view wm)
 

--- a/lib/lwd/lwd.ml
+++ b/lib/lwd/lwd.ml
@@ -82,20 +82,17 @@ let dummy = Pure (Any.any ())
 let operator desc =
   Operator { value = Eval_none; trace = T0; desc; trace_idx = I0 }
 
-let map f x = inj (
+let map x ~f = inj (
     match prj x with
     | Pure vx -> Pure (f vx)
     | x -> operator (Map (x, f))
   )
 
-let map2 f x y = inj (
+let map2 x y ~f = inj (
     match prj x, prj y with
     | Pure vx, Pure vy -> Pure (f vx vy)
     | x, y -> operator (Map2 (x, y, f))
   )
-
-let map' x f = map f x
-let map2' x y f = map2 f x y
 
 let pair x y = inj (
     match prj x, prj y with
@@ -115,7 +112,7 @@ let join child = inj (
     | child -> operator (Join { child; intermediate = None })
   )
 
-let bind x f = join (map f x)
+let bind x ~f = join (map ~f x)
 
 (* Management of trace indices *)
 
@@ -624,8 +621,8 @@ let quick_release root =
   flush_or_fail None queue
 
 module Infix = struct
-  let (>>=) = bind
-  let (>|=) = map'
+  let (>>=) x f = bind x ~f
+  let (>|=) x f = map x ~f
   let (<*>) = app
 end
 

--- a/lib/lwd/lwd.mli
+++ b/lib/lwd/lwd.mli
@@ -17,25 +17,19 @@ val return : 'a -> 'a t
 val pure : 'a -> 'a t
 (** Alias to {!return} *)
 
-val map : ('a -> 'b) -> 'a t -> 'b t
-(** [map f d] is the document that has value [f x] whenever [d] has value [x] *)
+val map : 'a t -> f:('a -> 'b) -> 'b t
+(** [map d ~f] is the document that has value [f x] whenever [d] has value [x] *)
 
-val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** [map2 f d1 d2] is the document that has value [f x1 x2] whenever
+val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+(** [map2 d1 d2 ~f] is the document that has value [f x1 x2] whenever
     [d1] has value [x1] and [d2] has value [x2] *)
-
-val map' : 'a t -> ('a -> 'b) -> 'b t
-(** Alias to {!map} with arguments flipped *)
-
-val map2' : 'a t -> 'b t -> ('a -> 'b -> 'c) -> 'c t
-(** Alias to {!map2} with arguments flipped *)
 
 val join : 'a t t -> 'a t
 (** Monadic operator [join d] is the document pointed to by document [d].
     This is powerful but potentially costly in case of recomputation.
 *)
 
-val bind : 'a t -> ('a -> 'b t) -> 'b t
+val bind : 'a t -> f:('a -> 'b t) -> 'b t
 (** Monadic bind, a mix of {!join} and {!map} *)
 
 val app : ('a -> 'b) t -> 'a t -> 'b t

--- a/lib/lwd/lwd_infix_letop.ml
+++ b/lib/lwd/lwd_infix_letop.ml
@@ -1,6 +1,6 @@
-let (let$) : 'a Lwd.t -> ('a -> 'b) -> 'b Lwd.t = Lwd.map'
+let (let$) : 'a Lwd.t -> ('a -> 'b) -> 'b Lwd.t = Lwd.Infix.(>|=)
 let (and$) : 'a Lwd.t -> 'b Lwd.t -> ('a * 'b) Lwd.t = Lwd.pair
-let (let$*) : 'a Lwd.t -> ('a -> 'b Lwd.t) -> 'b Lwd.t = Lwd.bind
+let (let$*) : 'a Lwd.t -> ('a -> 'b Lwd.t) -> 'b Lwd.t = Lwd.Infix.(>>=)
 
 let ($=) : 'a Lwd.var -> 'a -> unit = Lwd.set
 let ($<-) : 'a Lwd_table.row -> 'a -> unit = Lwd_table.set

--- a/lib/lwd/lwd_table.ml
+++ b/lib/lwd/lwd_table.ml
@@ -501,7 +501,7 @@ let map_reduce mapper monoid source =
           )
     end
   } in
-  Lwd.map eval (Lwd.get_prim (Lazy.force reduction.primitive))
+  Lwd.map ~f:eval (Lwd.get_prim (Lazy.force reduction.primitive))
 
 let reduce monoid source = map_reduce (fun _ x -> x) monoid source
 

--- a/lib/lwd/lwd_utils.ml
+++ b/lib/lwd/lwd_utils.ml
@@ -2,7 +2,7 @@
 type 'a monoid = 'a * ('a -> 'a -> 'a)
 
 let lift_monoid (zero, plus) =
-  (Lwd.return zero, Lwd.map2 plus)
+  (Lwd.return zero, Lwd.map2 ~f:plus)
 
 let map_reduce inj (zero, plus) items =
   let rec cons_monoid c xs v =
@@ -22,25 +22,25 @@ let reduce monoid items = map_reduce (fun x -> x) monoid items
 let rec cons_lwd_monoid plus c xs v =
   match xs with
   | (c', v') :: xs when c = c' ->
-    cons_lwd_monoid plus (c + 1) xs (Lwd.map2 plus v' v)
+    cons_lwd_monoid plus (c + 1) xs (Lwd.map2 ~f:plus v' v)
   | xs -> (c, v) :: xs
 
 let pack (zero, plus) items =
   match List.fold_left (cons_lwd_monoid plus 0) [] items with
   | [] -> Lwd.return zero
   | (_,x) :: xs ->
-    List.fold_left (fun acc (_, v) -> Lwd.map2 plus v acc) x xs
+    List.fold_left (fun acc (_, v) -> Lwd.map2 ~f:plus v acc) x xs
 
 let pack_seq (zero, plus) items =
   match Seq.fold_left (cons_lwd_monoid plus 0) [] items with
   | [] -> Lwd.return zero
   | (_,x) :: xs ->
-    List.fold_left (fun acc (_, v) -> Lwd.map2 plus v acc) x xs
+    List.fold_left (fun acc (_, v) -> Lwd.map2 ~f:plus v acc) x xs
 
 let rec map_l (f:'a -> 'b Lwd.t) (l:'a list) : 'b list Lwd.t =
   match l with
   | [] -> Lwd.return []
-  | x :: tl -> Lwd.map2 List.cons (f x) (map_l f tl)
+  | x :: tl -> Lwd.map2 ~f:List.cons (f x) (map_l f tl)
 
 let flatten_l (l:'a Lwd.t list) : 'a list Lwd.t =
   map_l (fun x->x) l

--- a/lib/nottui/nottui.ml
+++ b/lib/nottui/nottui.ml
@@ -35,7 +35,7 @@ end = struct
 
   let make () =
     let v = Lwd.var 0 in
-    (v, Lwd.map (fun i -> Handle (i, v)) (Lwd.get v))
+    (v, Lwd.map ~f:(fun i -> Handle (i, v)) (Lwd.get v))
 
   let empty : status = Empty
 
@@ -856,12 +856,11 @@ struct
       | Some quit -> quit
       | None -> Lwd.var false
     in
-    let t =
-      t |> Lwd.map (Ui.event_filter (function
-          | `Key (`ASCII 'Q', [`Ctrl]) | `Key (`Escape, []) ->
-            Lwd.set quit true; `Handled
-          | _ -> `Unhandled
-        ))
+    let t = Lwd.map t ~f:(Ui.event_filter (function
+        | `Key (`ASCII 'Q', [`Ctrl]) | `Key (`Escape, []) ->
+          Lwd.set quit true; `Handled
+        | _ -> `Unhandled
+      ))
     in
     match term with
     | Some term -> run_with_term term ?tick_period ?tick ~renderer quit t


### PR DESCRIPTION
As suggested by @smondet, get rid of `map'` and `map2'` and for other combinators:
- take "t" first
- label the functional argument `~f`

The monadic core of Lwd API now looks like:
```ocaml
val return : 'a -> 'a t   
val map : 'a t -> f:('a -> 'b) -> 'b t                                          
val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t                           
val join : 'a t t -> 'a t                                                       
val bind : 'a t -> f:('a -> 'b t) -> 'b t                                       
```

If nobody complains or has suggestions, I will merge this PR in a few days.