### PR TITLE
Fix Svg namespace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,16 @@ jobs:
         # operating-system: [macos-latest, ubuntu-latest, windows-latest]
         ocaml-version: [ '4.03.0', '4.04.2', '4.05.0', '4.06.1', '4.07.1', '4.08.1', '4.09.1', '4.10.1', '4.11.1' ]
     steps:
-    - uses: actions/checkout@master
-    - uses: avsm/setup-ocaml@master
+    - uses: actions/checkout@v2
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        # A directory to store and save the cache
+        path: ~/.opam
+        # An explicit key for restoring and saving the cache
+        key: ${{ matrix.os }}-${{ matrix.ocaml-version }}-${{ hashFiles('*.opam') }}-build
+    - name: Set up OCaml ${{ matrix.ocaml-version }}
+      uses: avsm/setup-ocaml@v1
       with:
         ocaml-version: ${{ matrix.ocaml-version }}
     - run: opam pin -n .

--- a/lib/lwd/lwd.mli
+++ b/lib/lwd/lwd.mli
@@ -74,10 +74,11 @@ type +'a prim
     A primitive is a resource with [acquire] and [release] functions
     to manage its lifecycle. *)
 
-val prim : acquire:(unit -> 'a) -> release:('a -> unit) -> 'a prim
+val prim : acquire:('a prim -> 'a) -> release:('a prim -> 'a -> unit) -> 'a prim
 (** create a new primitive document.
     @param acquire is called when the document becomes observed (indirectly)
-    via at least one {!root}.
+    via at least one {!root}.  The resulting primitive is passed as an argument
+    to support certain recursive use cases.
     @param release is called when the document is no longer observed.
     Internal resources can be freed. *)
 

--- a/lib/lwd/lwd.mli
+++ b/lib/lwd/lwd.mli
@@ -39,8 +39,13 @@ val app : ('a -> 'b) t -> 'a t -> 'b t
 val pair : 'a t -> 'b t -> ('a * 'b) t
 (** [pair a b] is [map2 (fun x y->x,y) a b] *)
 
-val impure : 'a t -> 'a t
 val is_pure : 'a t -> 'a option
+(** [is_pure x] will return [Some v] if [x] was built with [pure v] or
+    [return v].
+
+    Normal code should not rely on the "reactive-ness" of a value, but this is
+    often useful for optimising reactive data structures.
+*)
 
 type 'a var
 (** The workhorse of Lwd: a mutable variable that also tracks dependencies.


### PR DESCRIPTION
Fix issue #20. Better solutions might appear in the future on: https://github.com/ocsigen/tyxml/issues/277.

Incidentally:
- I removed Impure operator; I don't see any use for it yet
- I augmented the primitive interface to give access to self instance