### PR TITLE
tyxml: workaround textarea.value semantics

### DIFF
--- a/lib/lwd/lwd.ml
+++ b/lib/lwd/lwd.ml
@@ -620,7 +620,7 @@ end
 
 (*$R
   let x = var 0 in
-  let y = map succ (get x) in
+  let y = map ~f:succ (get x) in
   let o_y = Lwd.observe y in
   assert_equal 1 (quick_sample o_y);
   set x 10;

--- a/lib/tyxml-lwd/tyxml_lwd.ml
+++ b/lib/tyxml-lwd/tyxml_lwd.ml
@@ -1405,8 +1405,9 @@ module Html : sig
     ([<optgroup_attrib], [<optgroup_content_fun], [>optgroup]) star
   val option :
     ([<option_attrib], [<option_content_fun], [>selectoption]) unary
-  val textarea :
-    ([<textarea_attrib], [<textarea_content], [>textarea]) unary
+  val textarea : ?a:[<textarea_attrib] attrib list -> string Lwd.t -> [>textarea] elt
+  (* Textarea syntactically looks like it takes its content from its children
+     nodes, but dynamic semantics use the value attribute :-( *)
   val keygen :
     ([<keygen_attrib], [>keygen]) nullary
   val progress :
@@ -1801,7 +1802,12 @@ end = struct
     Raw_html.datalist ?children ?a ()
   let optgroup ~label ?a elts = Raw_html.optgroup ~label ?a (pures elts)
   let option                = unary Raw_html.option
-  let textarea              = unary Raw_html.textarea
+  let textarea ?(a=[]) txt =
+    let value = Lwd.map ~f:(fun txt -> Some (Js.string txt)) txt in
+    let attrib = Attrib.Attrib {name="value"; value} in
+    Raw_html.textarea ~a:(attrib :: a)
+      (Lwd.pure (Lwd.pure Lwd_seq.empty))
+  (*(Lwd.pure (Xml.pcdata txt))*)
   let keygen                = Raw_html.keygen
   let progress              = star Raw_html.progress
   let meter                 = star Raw_html.meter

--- a/lib/tyxml-lwd/tyxml_lwd.mli
+++ b/lib/tyxml-lwd/tyxml_lwd.mli
@@ -762,8 +762,9 @@ module Html : sig
     ([<optgroup_attrib], [<optgroup_content_fun], [>optgroup]) star
   val option :
     ([<option_attrib], [<option_content_fun], [>selectoption]) unary
-  val textarea :
-    ([<textarea_attrib], [<textarea_content], [>textarea]) unary
+  val textarea : ?a:[<textarea_attrib] attrib list -> string Lwd.t -> [>textarea] elt
+  (* Textarea syntactically looks like it takes its content from its children
+     nodes, but dynamic semantics use the value attribute :-( *)
   val keygen :
     ([<keygen_attrib], [>keygen]) nullary
   val progress :


### PR DESCRIPTION
Textarea contents is syntactically specified using text nodes but dynamically maintained in value property.
I don't understand what went through the mind of people designing this.

Anyway, this PR is to keep track of the workaround: override textarea to take input text directly and store it in value property.
(Thought: content editable is likely strictly better than textarea)