### PR TITLE
Lwd_seq: fix important bug in diff

### DIFF
--- a/lib/lwd/lwd_seq.ml
+++ b/lib/lwd/lwd_seq.ml
@@ -236,6 +236,7 @@ module Reducer = struct
         if dropped_leaf > -1 then (
           st.dropped.(dropped_leaf) <- b;
           st.dropped_leaf <- dropped_leaf + 1;
+          assert (st.dropped_leaf <= st.dropped_join);
         );
         t'.mark <- mark land lnot both_mask
       ) else if mark = -1 then (
@@ -253,10 +254,11 @@ module Reducer = struct
     | XJoin {a = Join t' as a; l; r; b} as t ->
       let mark = t'.mark in
       if mark land both_mask = old_mask then (
-        let dropped_leaf = st.dropped_leaf in
-        if dropped_leaf > -1 then (
-          st.dropped.(dropped_leaf) <- b;
-          st.dropped_leaf <- dropped_leaf + 1;
+        let dropped_join = st.dropped_join in
+        if dropped_join > -1 then (
+          st.dropped.(dropped_join) <- b;
+          st.dropped_join <- dropped_join - 1;
+          assert (st.dropped_leaf <= st.dropped_join);
         );
         t'.mark <- mark land lnot both_mask;
         unmark_old st l;
@@ -352,8 +354,8 @@ module Reducer = struct
       let nb_dropped = sold.marked - (sold.blocked + snew.blocked) in
       let st = {
         dropped = if get_dropped then Array.make nb_dropped None else [||];
-        dropped_leaf = if get_dropped then 0 else -1;
-        dropped_join = if get_dropped then nb_dropped else -1;
+        dropped_leaf = if get_dropped then 0 else - 1;
+        dropped_join = if get_dropped then nb_dropped - 1 else - 1;
         shared = Array.make (sold.shared + snew.shared) Nil;
         shared_x = Array.make (sold.shared + snew.shared) [];
         shared_index = 0;

--- a/lib/lwd/lwd_seq.ml
+++ b/lib/lwd/lwd_seq.ml
@@ -109,12 +109,13 @@ module Reducer = struct
   let new_shared stats = stats.shared <- stats.shared + 1
   let new_blocked stats = stats.blocked <- stats.blocked + 1
 
-  let rec block stats = function
+  let rec block stats mask = function
     | Nil -> ()
     | Leaf t' ->
       let mark = t'.mark in
       if mark land both_mask <> both_mask && mark land both_mask <> 0
       then (
+        if mark land mask = 0 then new_marked stats else assert false;
         new_blocked stats;
         t'.mark <- mark lor both_mask
       )
@@ -122,10 +123,11 @@ module Reducer = struct
       let mark = t'.mark in
       if mark land both_mask <> both_mask && mark land both_mask <> 0
       then (
+        if mark land mask = 0 then new_marked stats else assert false;
         new_blocked stats;
         t'.mark <- mark lor both_mask;
-        block stats t'.l;
-        block stats t'.r;
+        block stats mask t'.l;
+        block stats mask t'.r;
       )
 
   let enqueue stats q mask = function
@@ -157,8 +159,8 @@ module Reducer = struct
           t'.mark <- -1;
           new_blocked stats;
           new_shared stats;
-          block stats t'.l;
-          block stats t'.r;
+          block stats mask t'.l;
+          block stats mask t'.r;
         ) else (
           (* First mark *)
           t'.mark <- mark lor mask;


### PR DESCRIPTION
This fixes an important bug in the diff algorithm of sequences:
- wrong accounting of marked nodes caused overflow of dropped nodes array
- dropped leaf nodes were overwritten by dropped join nodes, causing incorrect traversal of dropped nodes.