### PR TITLE
Tyxml_lwd scheduler: WIP

### DIFF
--- a/examples/minesweeper/main.ml
+++ b/examples/minesweeper/main.ml
@@ -70,14 +70,8 @@ let onload _ =
       Lwd.join (Lwd_table.reduce Lwd_seq.lwd_monoid boards);
     ]
   in
-  (*let root = Lwd.observe (Lwdom.to_fragment doc) in*)
-  let root = Lwd.observe doc in
-  Lwd.set_on_invalidate root (fun _ ->
-      ignore (Dom_html.window##requestAnimationFrame
-                (Js.wrap_callback (fun _ -> ignore (Lwd.quick_sample root)))
-             ));
-  List.iter (Dom.appendChild main)
-    (Lwd_seq.to_list (Lwd.quick_sample root) : _ node list :> raw_node list);
+  let _ : Lwdom.Scheduler.job =
+    Lwdom.Scheduler.append_to_dom doc main in
   Js._false
 
 let _ = Dom_html.window##.onload := Dom_html.handler onload

--- a/lib/tyxml-lwd/tyxml_lwd.mli
+++ b/lib/tyxml-lwd/tyxml_lwd.mli
@@ -831,5 +831,23 @@ module Lwdom : sig
   (** Make a reactive attribute *)
 
   val to_node : _ node -> raw_node
+
+  module Scheduler : sig
+    val on_next_frame : (Lwd.release_queue -> unit) -> unit
+
+    type job
+    val append_to_dom : 'a node live -> #Dom.node Js.t -> job
+    val disable : job -> unit
+    val reenable : job -> unit
+
+    type limit = {
+      cycles_warning: int; (* 5 *)
+      cycles_max: int;     (* 15 *)
+      time_budget: float;  (* 16.6 *)
+      time_warning: bool;  (* true *)
+    }
+
+    val set_limit : job -> limit -> unit
+  end
 end
 


### PR DESCRIPTION
This PR introduces a scheduler for updating the DOM, such that it is no longer necessary to manually use Lwd.root and to call requestAnimationFrame.

The important part is this new module in `Tyxml_lwd.Lwdom`:

```
module Scheduler : sig

  val on_next_frame : (Lwd.release_queue -> unit) -> unit
  (** Add a function to execute at the beginning of next frame, before updating the DOM *)

  type job
  (** A scheduling job maintains a binding between a declarative specification,
      a value of type `_ node live`, and a real DOM node. *)

  val append_to_dom : 'a node live -> #Dom.node Js.t -> job
  (** [append_to_dom spec dom_node] returns a job that adds
      and maintains up to date all nodes from [spec] as children
      of [dom_node] *)

  val disable : job -> unit
  (** Stop a job. Associated nodes will no longer be updated.
      They are available for garbage collection, unless the job
      is [reenable]d later. *)

  val reenable : job -> unit
  (** Resume a stoped job. Changes will be tracked and the DOM updated again. *)
 
  (** Impose limit on non-stabilizing jobs.
      Normally, after a single pass, the document should be updated.
      However, in certain circumstances, multiple passes are necessary.
      For instance some updates triggered a change in a layout condition that requires
      the tree to be updated.
      However, these changes should converge quickly and yield a stable document after
      a few number of passes.
     
      The settings below determine how ill-behaved job should be handled. *)
  type limit = {

    cycles_warning: int;
    (** Warn in the console if a job has not stabilized after
        [cycles_warning] update cycles.
        default: 5 *)

    cycles_max: int;
    (** Stop updating a job in current frame if it has not stabilized
        after [cycles_max] update cycles.
        Evaluation will continue for next frame.*)
        default: 15 *)

    time_budget: float;
    (** Stop updating a job in current frame if it has not stabilized
        and [time_budget] milliseconds have already been spent computing
        the current frame.
        Evaluation will continue for next frame.
        The intention is to avoid missing too much frames in degenerate
        circumstances.
        default: 16.6 (in milliseconds) *)

    time_warning: bool;
    (** Warn, in error console, if a job exceeds its time budget.
        default: true *)
  }

  val set_limit : job -> limit -> unit
  (** Change the limits of a job *)
end
```

The limit strategies are intended to keep the application usable in degenerate conditions.
They play on two parameters: number of update cycles and time spent updating.

These limits should not be reached in a well-designed application, they are here to offer a "best-effort"
fallback and help debugging performance issues without freezing the page.

TODO:
- improve the logging facility, especially in case of error
- disabling a job does not but should remove bound nodes from the DOM
- document API inline