### PR TITLE
Prevent splits from being moved out of bounds

### DIFF
--- a/lib/nottui/nottui_widgets.ml
+++ b/lib/nottui/nottui_widgets.ml
@@ -308,7 +308,8 @@ let h_pane left right =
       | Split _ -> ui
       | Re_split {at; _} ->
         Ui.transient_sensor (fun ~x ~y:_ ~w ~h:_ () ->
-            Lwd.set state_var (Split {pos = (at - x); max = w})
+            let newpos = at - x |> Stdlib.min w |> Stdlib.max 0 in
+            Lwd.set state_var (Split {pos = newpos; max = w})
           ) ui
     in
     ui
@@ -347,7 +348,8 @@ let v_pane top bot =
       | Split _ -> ui
       | Re_split {at; _} ->
         Ui.transient_sensor (fun ~x:_ ~y ~w:_ ~h () ->
-            Lwd.set state_var (Split {pos = (at - y); max = h})
+            let newpos = at - y |> Stdlib.min h |> Stdlib.max 0 in
+            Lwd.set state_var (Split {pos = newpos; max = h})
           ) ui
     in
     ui


### PR DESCRIPTION
This stops a user from moving a horizontal split off the right of the screen, or a vertical split off the bottom of the screen. Normally that would lead to an irrecoverable situation.

