### PR TITLE
Nottui.Ui_loop: add option to opt-out of default quit bindings in run

### DIFF
--- a/lib/nottui/nottui.ml
+++ b/lib/nottui/nottui.ml
@@ -849,13 +849,15 @@ struct
     ignore (Lwd.quick_release quit)
 
   let run ?tick_period ?tick ?term ?(renderer=Renderer.make ())
-          ?quit t =
+          ?quit ?(quit_on_escape=true) ?(quit_on_ctrl_q=true) t =
     let quit = match quit with
       | Some quit -> quit
       | None -> Lwd.var false
     in
     let t = Lwd.map t ~f:(Ui.event_filter (function
-        | `Key (`ASCII 'Q', [`Ctrl]) | `Key (`Escape, []) ->
+        | `Key (`ASCII 'Q', [`Ctrl]) when quit_on_ctrl_q ->
+          Lwd.set quit true; `Handled
+        | `Key (`Escape, []) when quit_on_escape ->
           Lwd.set quit true; `Handled
         | _ -> `Unhandled
       ))

--- a/lib/nottui/nottui.mli
+++ b/lib/nottui/nottui.mli
@@ -353,11 +353,13 @@ sig
   val run :
     ?tick_period:float -> ?tick:(unit -> unit) ->
     ?term:Term.t -> ?renderer:Renderer.t ->
-    ?quit:bool Lwd.var -> ui Lwd.t -> unit
+    ?quit:bool Lwd.var -> ?quit_on_escape:bool ->
+    ?quit_on_ctrl_q:bool -> ui Lwd.t -> unit
   (** Repeatedly run steps of the main loop, until either:
       - [quit] becomes true,
       - the ui computation raises an exception,
-      - if [quit] was not provided, wait for Ctrl-Q event
+      - if [quit_on_ctrl_q] was true or not provided, wait for Ctrl-Q event
+      - if [quit_on_escape] was true or not provided, wait for Escape event
 
       Specific [term] or [renderer] instances can be provided, otherwise new
       ones will be allocated and released.


### PR DESCRIPTION
By default, [Nottui.Ui_loop.run] quits whenever the user types [Ctrl+Q] and [Escape].
There was previously no way to opt-out of this, and since the [run] loop intercepts
all key events, this meant that there was no way to rebind [Escape] to other actions
when using [run].