### PR TITLE
brr-lwd: Fix multiple reactive attrs or events

### DIFF
--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -222,7 +222,7 @@ let attach_attribs el attribs =
           ignore (Lwd_seq.Reducer.reduce reducer': _ option)
         in
         Lwd.map ~f:update ats
-    ) (pure_unit, fun _ _ -> pure_unit)
+    ) (pure_unit, Lwd.map2 ~f:(fun () () -> ()))
     attribs
 
 let listen el (Handler {opts; type'; func}) =
@@ -257,7 +257,7 @@ let attach_events el events =
           ignore (Lwd_seq.Reducer.reduce reducer': _ option)
         in
         Lwd.map ~f:update ats
-    ) (pure_unit, fun _ _ -> pure_unit)
+    ) (pure_unit, Lwd.map2 ~f:(fun () () -> ()))
     events
 
 let v ?d ?(at=[]) ?(ev=[]) tag children =


### PR DESCRIPTION
Hello and thanks for this gorgeous masterpiece of genius coding!

I've lost my hair trying to have multiple reactive attributes in brr-lwd. It turns out it was simply because the reducing of the strong profunctor was cooked.

I fixed the same issue for event handlers, as it looked similarly suspicious.

cc @voodoos (who confirmed to me having the same issue)