### PR TITLE
change dependency from notty to notty-community

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,7 @@
  (name nottui)
  (synopsis "UI toolkit for the terminal built on top of Notty and Lwd")
  (documentation "https://let-def.github.io/lwd/doc")
- (depends (lwd (= :version)) (notty (>= 0.2))
+ (depends (lwd (= :version)) (notty-community (>= 0.2))
           (cbor :with-test) ; for the examples
           (containers :with-test))) ; for the examples
 
@@ -28,7 +28,7 @@
  (name nottui-unix)
  (synopsis "UI toolkit for the UNIX terminal built on top of Notty and Lwd")
  (documentation "https://let-def.github.io/lwd/doc")
- (depends (lwd (= :version)) (notty (>= 0.2)) (nottui (= :version))
+ (depends (lwd (= :version)) (notty-community (>= 0.2)) (nottui (= :version))
           (cbor :with-test) ; for the examples
           (containers :with-test)))
 
@@ -49,10 +49,10 @@
  (name nottui-pretty)
  (synopsis "A pretty-printer based on PPrint rendering UIs")
  (documentation "https://let-def.github.io/lwd/doc")
- (depends (nottui (= :version)) (notty (>= 0.2))))
+ (depends (nottui (= :version)) (notty-community (>= 0.2))))
 
 (package
  (name nottui-lwt)
  (synopsis "Run Nottui UIs in Lwt")
  (documentation "https://let-def.github.io/lwd/doc")
- (depends lwt (nottui (= :version)) (notty (>= 0.2))))
+ (depends lwt (nottui (= :version)) (notty-community (>= 0.2))))

--- a/lib/nottui-lwt/dune
+++ b/lib/nottui-lwt/dune
@@ -1,4 +1,4 @@
 (library
  (name nottui_lwt)
  (public_name nottui-lwt)
- (libraries nottui notty.lwt))
+ (libraries nottui notty-community.lwt))

--- a/lib/nottui-unix/dune
+++ b/lib/nottui-unix/dune
@@ -2,4 +2,4 @@
  (name nottui_unix)
  (public_name nottui-unix)
  (wrapped false)
- (libraries lwd nottui notty.unix))
+ (libraries lwd nottui notty-community.unix))

--- a/lib/nottui/dune
+++ b/lib/nottui/dune
@@ -2,4 +2,4 @@
  (name nottui)
  (public_name nottui)
  (wrapped false)
- (libraries lwd notty))
+ (libraries lwd notty-community))

--- a/nottui-lwt.opam
+++ b/nottui-lwt.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "3.5"}
   "lwt"
   "nottui" {= version}
-  "notty" {>= "0.2"}
+  "notty-community" {>= "0.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/nottui-pretty.opam
+++ b/nottui-pretty.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "3.5"}
   "nottui" {= version}
-  "notty" {>= "0.2"}
+  "notty-community" {>= "0.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/nottui-unix.opam
+++ b/nottui-unix.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "3.5"}
   "lwd" {= version}
-  "notty" {>= "0.2"}
+  "notty-community" {>= "0.2"}
   "nottui" {= version}
   "cbor" {with-test}
   "containers" {with-test}

--- a/nottui.opam
+++ b/nottui.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "3.5"}
   "lwd" {= version}
-  "notty" {>= "0.2"}
+  "notty-community" {>= "0.2"}
   "cbor" {with-test}
   "containers" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
this community-maintaned version of notty worked in my limited testing and is compatible with ocaml 5.4