### PR TITLE
Reactive properties and styles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ v0.4 - Alpha 0.4 UNRELEASED
 - Lwd.set: change binding before invalidation, otherwise the old value could be re-observed (reported by @voodoos)
 - brr-lwd: support declarative events and set of css classes
 - Nottui: fix treatment of some terminal events that were delayed because of improper buffer flushing, reported by @darrenldl
+- brr-lwd: Fix handling of multiple reactive attributes (by @panglesd)
 
 v0.3 - Alpha 0.3
 ======

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ v0.4 - Alpha 0.4 UNRELEASED
 - brr-lwd: support declarative events and set of css classes
 - Nottui: fix treatment of some terminal events that were delayed because of improper buffer flushing, reported by @darrenldl
 - brr-lwd: Fix handling of multiple reactive attributes (by @panglesd)
+- brr-lwd: Add support for reactive styles and properties (by @panglesd)
 
 v0.3 - Alpha 0.3
 ======

--- a/CHANGES
+++ b/CHANGES
@@ -1,12 +1,17 @@
-v0.4 - Alpha 0.4 UNRELEASED
+v0.5 - Alpha 0.5 UNRELEASED
+======
+
+- brr-lwd: Fix handling of multiple reactive attributes (by @panglesd, #53)
+- brr-lwd: Add support for reactive styles and properties (by @panglesd, #60)
+
+v0.4 - Alpha 0.4
 ======
 
 - Add Lwd.update (by @OlivierNicole and @Julow) and Lwd.may_update functions
 - Lwd.set: change binding before invalidation, otherwise the old value could be re-observed (reported by @voodoos)
 - brr-lwd: support declarative events and set of css classes
 - Nottui: fix treatment of some terminal events that were delayed because of improper buffer flushing, reported by @darrenldl
-- brr-lwd: Fix handling of multiple reactive attributes (by @panglesd)
-- brr-lwd: Add support for reactive styles and properties (by @panglesd)
+- Introduce Nottui_unix: move platform-specific code of Nottui to a separate library (by @Dinosaure and @Reynir, #44, #51)
 
 v0.3 - Alpha 0.3
 ======

--- a/examples/reactive-props-brr/Makefile
+++ b/examples/reactive-props-brr/Makefile
@@ -1,0 +1,9 @@
+ROOT=$(realpath $(PWD)/../..)
+NAME=$(subst $(ROOT)/,,$(realpath $(PWD)))
+
+all:
+	dune build index.html main.js
+	@echo "open $(ROOT)/_build/default/$(NAME)/index.html"
+
+clean:
+	dune clean

--- a/examples/reactive-props-brr/dune
+++ b/examples/reactive-props-brr/dune
@@ -1,0 +1,21 @@
+(executables
+ (names main)
+ (libraries js_of_ocaml brr lwd brr-lwd)
+ (modes byte))
+
+(rule
+ (targets main.js)
+ (action
+  (run
+   %{bin:js_of_ocaml}
+   --noruntime
+   %{lib:js_of_ocaml-compiler:runtime.js}
+   --source-map
+   %{dep:main.bc}
+   -o
+   %{targets}
+   --pretty)))
+
+(alias
+ (name default)
+ (deps main.js index.html))

--- a/examples/reactive-props-brr/index.html
+++ b/examples/reactive-props-brr/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Reactive props</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <script type="text/javascript" src="main.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/examples/reactive-props-brr/main.ml
+++ b/examples/reactive-props-brr/main.ml
@@ -25,7 +25,7 @@ let string var =
 let checkbox s check description =
   let checked =
     let$ s = s in
-    (Jstr.v "checked", check s |> Jv.of_bool)
+    Elwd.P (El.Prop.checked, check s)
   in
   let checkbox_el =
     Elwd.input

--- a/examples/reactive-props-brr/main.ml
+++ b/examples/reactive-props-brr/main.ml
@@ -1,0 +1,76 @@
+open Brr
+open Brr_lwd
+open Lwd_infix
+
+(* A string input, whose value is synced with the given var *)
+let string var =
+  let h =
+   fun ev ->
+    let el = ev |> Brr.Ev.target |> Brr.Ev.target_to_jv in
+    let new_value = Jv.get el "value" |> Jv.to_string in
+    Brr.Console.(log [ new_value ]);
+    Lwd.set var new_value
+  in
+  let ev = [ `P (Brr_lwd.Elwd.handler Brr.Ev.input h) ] in
+  let at =
+    let value =
+      let$ v = Lwd.get var in
+      Brr.At.value (Jstr.of_string v)
+    in
+    [ `R value; `P (Brr.At.type' (Jstr.v "text")) ]
+  in
+  Brr_lwd.Elwd.input ~at ~ev ()
+
+(* A checkbox, whose checked prop is synced the reactive [check s] *)
+let checkbox s check description =
+  let checked =
+    let$ s = s in
+    (Jstr.v "checked", check s |> Jv.of_bool)
+  in
+  let checkbox_el =
+    Elwd.input
+      ~at:[ `P (At.type' (Jstr.v "checkbox")) ]
+      ~st:[ `P (Jstr.v "pointer-events", Jstr.v "none") ]
+      ~pr:[ `R checked ] ()
+  in
+  Elwd.div [ `R checkbox_el; `P (El.txt' description) ]
+
+(* A string input, and checks whether it's long enough, contains uppercase,
+   contains numbers *)
+let ui =
+  let s = Lwd.var "" in
+  let string_input = string s in
+  let s = Lwd.get s in
+  let checkbox_length =
+    let check s = String.length s >= 5 in
+    checkbox s check "Has length at least 5"
+  in
+  let checkbox_uppercase =
+    let check s = String.exists (function 'A' .. 'Z' -> true | _ -> false) s in
+    checkbox s check "Has uppercase"
+  in
+  let checkbox_numbers =
+    let check s = String.exists (function '0' .. '9' -> true | _ -> false) s in
+    checkbox s check "Has numbers"
+  in
+  Elwd.div [ `R string_input ; `R checkbox_length ; `R checkbox_numbers ; `R checkbox_uppercase ]
+
+(* Injection of reactive element to the DOM *)
+let () =
+  let ui = Lwd.observe ui in
+  let on_invalidate _ =
+    Console.(log [ str "on invalidate" ]);
+    let _ : int =
+      G.request_animation_frame @@ fun _ ->
+      let _ui = Lwd.quick_sample ui in
+      ()
+    in
+    ()
+  in
+  let on_load _ =
+    Console.(log [ str "onload" ]);
+    El.append_children (Document.body G.document) [ Lwd.quick_sample ui ];
+    Lwd.set_on_invalidate ui on_invalidate
+  in
+  ignore (Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window));
+  ()

--- a/examples/reactive-styles-brr/Makefile
+++ b/examples/reactive-styles-brr/Makefile
@@ -1,0 +1,9 @@
+ROOT=$(realpath $(PWD)/../..)
+NAME=$(subst $(ROOT)/,,$(realpath $(PWD)))
+
+all:
+	dune build index.html main.js
+	@echo "open $(ROOT)/_build/default/$(NAME)/index.html"
+
+clean:
+	dune clean

--- a/examples/reactive-styles-brr/dune
+++ b/examples/reactive-styles-brr/dune
@@ -1,0 +1,21 @@
+(executables
+ (names main)
+ (libraries js_of_ocaml brr lwd brr-lwd)
+ (modes byte))
+
+(rule
+ (targets main.js)
+ (action
+  (run
+   %{bin:js_of_ocaml}
+   --noruntime
+   %{lib:js_of_ocaml-compiler:runtime.js}
+   --source-map
+   %{dep:main.bc}
+   -o
+   %{targets}
+   --pretty)))
+
+(alias
+ (name default)
+ (deps main.js index.html))

--- a/examples/reactive-styles-brr/index.html
+++ b/examples/reactive-styles-brr/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Reactive styles</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <script type="text/javascript" src="main.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/examples/reactive-styles-brr/main.ml
+++ b/examples/reactive-styles-brr/main.ml
@@ -1,0 +1,84 @@
+open Brr
+open Brr_lwd
+open Lwd_infix
+
+(* A float input, whose value is synced with the given var *)
+let float var =
+  let h =
+   fun ev ->
+    let el = ev |> Brr.Ev.target |> Brr.Ev.target_to_jv in
+    let new_value = Jv.get el "value" |> Jv.to_string |> float_of_string in
+    Brr.Console.(log [ new_value ]);
+    Lwd.set var new_value
+  in
+  let ev = [ `P (Brr_lwd.Elwd.handler Brr.Ev.input h) ] in
+  let at =
+    let v =
+      let$ v = Lwd.get var in
+      Brr.At.value (Jstr.of_float v)
+    in
+    [ `R v; `P (Brr.At.type' (Jstr.v "number")) ]
+  in
+  Brr_lwd.Elwd.input ~at ~ev ()
+
+(* Two float input (x and y), and a square whose absolute position is given by x
+   and y *)
+let ui =
+  let top = Lwd.var 1.0 in
+  let set_top = float top in
+  let left = Lwd.var 1.0 in
+  let set_left = float left in
+  let block =
+    let top =
+      let$ top = Lwd.get top in
+      let top = Jstr.append (Jstr.of_float top) (Jstr.v "px") in
+      (El.Style.top, top)
+    in
+    let left =
+      let$ left = Lwd.get left in
+      let left = Jstr.append (Jstr.of_float left) (Jstr.v "px") in
+      (El.Style.left, left)
+    in
+    let st =
+      [
+        `R top;
+        `R left;
+        `P (El.Style.width, Jstr.v "50px");
+        `P (El.Style.height, Jstr.v "50px");
+        `P (El.Style.position, Jstr.v "absolute");
+        `P (El.Style.background_color, Jstr.v "red");
+      ]
+    in
+    Elwd.div ~st []
+  in
+  let playground =
+    Elwd.div
+      ~st:
+        [
+          `P (El.Style.width, Jstr.v "1000px");
+          `P (El.Style.height, Jstr.v "1000px");
+          `P (El.Style.position, Jstr.v "relative");
+        ]
+      [ `R block ]
+  in
+  Elwd.div [ `R set_top; `R set_left; `R playground ]
+
+(* Injection of reactive element to the DOM *)
+let () =
+  let ui = Lwd.observe ui in
+  let on_invalidate _ =
+    Console.(log [ str "on invalidate" ]);
+    let _ : int =
+      G.request_animation_frame @@ fun _ ->
+      let _ui = Lwd.quick_sample ui in
+      ()
+    in
+    ()
+  in
+  let on_load _ =
+    Console.(log [ str "onload" ]);
+    El.append_children (Document.body G.document) [ Lwd.quick_sample ui ];
+    Lwd.set_on_invalidate ui on_invalidate
+  in
+  ignore (Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window));
+  ()

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -227,6 +227,8 @@ let style_kv =
   let dummy_kv = (Jstr.empty, Jstr.empty) in
   { unset_kv; set_kv; dummy_kv }
 
+type prop = P : ('a El.Prop.t * 'a) -> prop
+
 let prop_kv =
   let unset_kv _prop_kv _el =
     ()
@@ -236,10 +238,10 @@ let prop_kv =
        This is also why Brr does not have a [El.unset_prop].
     *)
   in
-  let set_kv ?old:_ (k,v) el =
-    Jv.set' (El.to_jv el) k v
+  let set_kv ?old:_ (P (k,v)) el =
+    El.set_prop k v el
   in
-  let dummy_kv = (Jstr.empty, Jv.undefined) in
+  let dummy_kv = P (El.Prop.width, 0) in
   { unset_kv; set_kv; dummy_kv }
 
 let attach_kv {set_kv; unset_kv; dummy_kv} el attribs =
@@ -353,7 +355,7 @@ type cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
-  ?pr:(Jstr.t * Jv.t) col ->
+  ?pr:prop col ->
   t col ->
   t Lwd.t
 (** The type for element constructors. This is simply {!v} with a
@@ -364,7 +366,7 @@ type void_cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
-  ?pr:(Jstr.t * Jv.t) col ->
+  ?pr:prop col ->
   unit ->
   t Lwd.t
 (** The type for void element constructors. This is simply {!v}

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -289,26 +289,18 @@ let v ?d ?(at=[]) ?(ev=[]) tag children =
   let children, impure_children = consume_children children in
   let el = El.v ?d ~at tag children in
   let result =
-    match impure_at, impure_children with
-    | [], None -> Lwd.pure el
-    | [], Some children ->
-      update_children el children
-    | at, None ->
-      Lwd.map ~f:(fun () -> el) (attach_attribs el at)
-    | at, Some children ->
-      Lwd.map2 ~f:(fun () el -> el)
-        (attach_attribs el at)
-        (update_children el children)
+    match impure_children with
+    | None -> Lwd.pure el
+    | Some children -> update_children el children
   in
-  List.iter (fun h -> ignore (listen el h)) ev;
-  let result =
-    match impure_ev with
+  let attach_impure attach impure result =
+    match impure with
     | [] -> result
-    | evs ->
-      Lwd.map2 ~f:(fun () el -> el)
-        (attach_events el evs)
-        result
+    | impure -> Lwd.map2 ~f:(fun () el -> el) (attach el impure) result
   in
+  let result = attach_impure attach_attribs impure_at result in
+  List.iter (fun h -> ignore (listen el h)) ev;
+  let result = attach_impure attach_events impure_ev result in
   result
 
 (** {1:els Element constructors} *)

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -188,13 +188,19 @@ let attach_attribs el attribs =
     then El.set_class v false el
     else El.set_at k None el
   in
+  let reset_kv (old_k, old_v) (k, v) =
+    let requires_unsetting =
+      not (Jstr.equal old_k k) || Jstr.equal old_k At.Name.class'
+    in
+    if requires_unsetting then
+      unset_kv (old_k, old_v);
+    set_kv (k, v)
+  in
   let set_lwd_at () =
     let prev = ref dummy_kv_at in
     fun at ->
-      if !prev != dummy_kv_at then
-        unset_kv !prev;
       let pair = At.to_pair at in
-      set_kv pair;
+      reset_kv !prev pair;
       prev := pair
   in
   Lwd_utils.map_reduce (function

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -212,6 +212,21 @@ let attr_kv =
   let dummy_kv = At.v Jstr.empty Jstr.empty in
   { unset_kv; set_kv; dummy_kv }
 
+let style_kv =
+  let unset_kv (k,_) el =
+    El.remove_inline_style k el
+  in
+  let set_kv ?old (k,v) el =
+    let () =
+      Option.iter (fun ((old_k, _) as old) ->
+          if not (Jstr.equal old_k k) then unset_kv old el)
+        old
+    in
+    El.set_inline_style k v el
+  in
+  let dummy_kv = (Jstr.empty, Jstr.empty) in
+  { unset_kv; set_kv; dummy_kv }
+
 let attach_kv {set_kv; unset_kv; dummy_kv} el attribs =
   let set_lwd_at () =
     let prev = ref dummy_kv in
@@ -248,6 +263,8 @@ let attach_kv {set_kv; unset_kv; dummy_kv} el attribs =
 
 let attach_attribs = attach_kv attr_kv
 
+let attach_styles = attach_kv style_kv
+
 let listen el (Handler {opts; type'; func}) =
   Ev.listen ?opts type' func (El.as_target el)
 
@@ -283,9 +300,10 @@ let attach_events el events =
     ) (pure_unit, Lwd.map2 ~f:(fun () () -> ()))
     events
 
-let v ?d ?(at=[]) ?(ev=[]) tag children =
+let v ?d ?(at=[]) ?(ev=[]) ?(st=[]) tag children =
   let at, impure_at = prepare_col at in
   let ev, impure_ev = prepare_col ev in
+  let st, impure_st = prepare_col st in
   let children, impure_children = consume_children children in
   let el = El.v ?d ~at tag children in
   let result =
@@ -301,20 +319,34 @@ let v ?d ?(at=[]) ?(ev=[]) tag children =
   let result = attach_impure attach_attribs impure_at result in
   List.iter (fun h -> ignore (listen el h)) ev;
   let result = attach_impure attach_events impure_ev result in
+  let result = attach_impure attach_styles impure_st result in
+  List.iter (fun kv -> style_kv.set_kv kv el) st;
   result
 
 (** {1:els Element constructors} *)
 
-type cons =  ?d:document -> ?at:At.t col -> ?ev:handler col -> t col -> t Lwd.t
+type cons =
+  ?d:document ->
+  ?at:At.t col ->
+  ?ev:handler col ->
+  ?st:(El.Style.prop * Jstr.t) col ->
+  t col ->
+  t Lwd.t
 (** The type for element constructors. This is simply {!v} with a
     pre-applied element name. *)
 
-type void_cons = ?d:document -> ?at:At.t col -> ?ev:handler col -> unit -> t Lwd.t
+type void_cons =
+  ?d:document ->
+  ?at:At.t col ->
+  ?ev:handler col ->
+  ?st:(El.Style.prop * Jstr.t) col ->
+  unit ->
+  t Lwd.t
 (** The type for void element constructors. This is simply {!v}
     with a pre-applied element name and without children. *)
 
-let cons name ?d ?at ?ev cs = v ?d ?at ?ev name cs
-let void_cons name ?d ?at ?ev () = v ?d ?at ?ev name []
+let cons name ?d ?at ?ev ?st cs = v ?d ?at ?ev ?st name cs
+let void_cons name ?d ?at ?ev ?st () = v ?d ?at ?ev ?st name []
 
 let a = cons Name.a
 let abbr = cons Name.abbr

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -182,19 +182,24 @@ type 'a kv = {
 }
 
 let attr_kv =
+  let is_class_at at = Jstr.equal at At.Name.class' in
   let set_kv (k, v) el =
-    if Jstr.equal k At.Name.class'
+    if is_class_at k
     then El.set_class v true el
     else El.set_at k (Some v) el
   in
   let unset_kv (k, v) el =
-    if Jstr.equal k At.Name.class'
+    if is_class_at k
     then El.set_class v false el
     else El.set_at k None el
   in
   let reset_kv ((old_k, _) as old) (k, v) el =
     let requires_unsetting =
-      not (Jstr.equal old_k k) || Jstr.equal old_k At.Name.class'
+    (* We have to unset the attribute if it was removed (changed name) or if a class
+       name was changed.  When an attribute is changed by multiple reactive values
+       the current behavior is undefined.  See
+       https://github.com/let-def/lwd/issues/59 *)
+      not (Jstr.equal old_k k) || is_class_at old_k
     in
     if requires_unsetting then
       unset_kv old el;

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -318,12 +318,18 @@ let attach_events el events =
     events
 
 let v ?d ?(at=[]) ?(ev=[]) ?(st=[]) ?(pr=[]) tag children =
+  (* Splitting impure and pure parts *)
   let at, impure_at = prepare_col at in
   let ev, impure_ev = prepare_col ev in
   let st, impure_st = prepare_col st in
   let pr, impure_pr = prepare_col pr in
   let children, impure_children = consume_children children in
+  (* Handling pure parts *)
   let el = El.v ?d ~at tag children in
+  List.iter (fun h -> ignore (listen el h)) ev;
+  List.iter (fun kv -> style_kv.set_kv kv el) st;
+  List.iter (fun kv -> prop_kv.set_kv kv el) pr;
+  (* Handling impure parts *)
   let result =
     match impure_children with
     | None -> Lwd.pure el
@@ -335,12 +341,9 @@ let v ?d ?(at=[]) ?(ev=[]) ?(st=[]) ?(pr=[]) tag children =
     | impure -> Lwd.map2 ~f:(fun () el -> el) (attach el impure) result
   in
   let result = attach_impure attach_attribs impure_at result in
-  List.iter (fun h -> ignore (listen el h)) ev;
   let result = attach_impure attach_events impure_ev result in
   let result = attach_impure attach_styles impure_st result in
-  List.iter (fun kv -> style_kv.set_kv kv el) st;
   let result = attach_impure attach_props impure_pr result in
-  List.iter (fun kv -> prop_kv.set_kv kv el) pr;
   result
 
 (** {1:els Element constructors} *)

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -175,47 +175,62 @@ let update_children
 
 let pure_unit = Lwd.pure ()
 
-let dummy_kv_at = (Jstr.empty, Jstr.empty)
+type 'a kv = {
+  unset_kv : 'a -> El.t -> unit;
+  set_kv : ?old:'a -> 'a -> El.t -> unit;
+  dummy_kv : 'a;
+}
 
-let attach_attribs el attribs =
-  let set_kv (k, v) =
+let attr_kv =
+  let set_kv (k, v) el =
     if Jstr.equal k At.Name.class'
     then El.set_class v true el
     else El.set_at k (Some v) el
   in
-  let unset_kv (k, v) =
+  let unset_kv (k, v) el =
     if Jstr.equal k At.Name.class'
     then El.set_class v false el
     else El.set_at k None el
   in
-  let reset_kv (old_k, old_v) (k, v) =
+  let reset_kv ((old_k, _) as old) (k, v) el =
     let requires_unsetting =
       not (Jstr.equal old_k k) || Jstr.equal old_k At.Name.class'
     in
     if requires_unsetting then
-      unset_kv (old_k, old_v);
-    set_kv (k, v)
+      unset_kv old el;
+    set_kv (k, v) el
   in
+  let set_kv ?old kv el =
+    let kv = At.to_pair kv in
+    let old = Option.map At.to_pair old in
+    match old with None -> set_kv kv el | Some old -> reset_kv old kv el
+  in
+  let unset_kv at el =
+    let kv = At.to_pair at in
+    unset_kv kv el
+  in
+  let dummy_kv = At.v Jstr.empty Jstr.empty in
+  { unset_kv; set_kv; dummy_kv }
+
+let attach_kv {set_kv; unset_kv; dummy_kv} el attribs =
   let set_lwd_at () =
-    let prev = ref dummy_kv_at in
+    let prev = ref dummy_kv in
     fun at ->
-      let pair = At.to_pair at in
-      reset_kv !prev pair;
-      prev := pair
+      set_kv ~old:!prev at el;
+      prev := at
   in
   Lwd_utils.map_reduce (function
       | `P _ -> assert false
       | `R at -> Lwd.map ~f:(set_lwd_at ()) at
       | `S ats ->
-        let set_at' at =
-          let kv = At.to_pair at in
-          set_kv kv;
+        let set_kv kv =
+          set_kv kv el;
           kv
         in
         let reducer =
           ref (Lwd_seq.Reducer.make
-                 ~map:set_at'
-                 ~reduce:(fun _ _ -> dummy_kv_at))
+                 ~map:set_kv
+                 ~reduce:(fun _ _ -> dummy_kv))
         in
         let update ats =
           let dropped, reducer' =
@@ -223,13 +238,15 @@ let attach_attribs el attribs =
           in
           reducer := reducer';
           Lwd_seq.Reducer.fold_dropped `Map
-            (fun kv () -> unset_kv kv)
+            (fun kv () -> unset_kv kv el)
             dropped ();
           ignore (Lwd_seq.Reducer.reduce reducer': _ option)
         in
         Lwd.map ~f:update ats
     ) (pure_unit, Lwd.map2 ~f:(fun () () -> ()))
     attribs
+
+let attach_attribs = attach_kv attr_kv
 
 let listen el (Handler {opts; type'; func}) =
   Ev.listen ?opts type' func (El.as_target el)

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -227,6 +227,21 @@ let style_kv =
   let dummy_kv = (Jstr.empty, Jstr.empty) in
   { unset_kv; set_kv; dummy_kv }
 
+let prop_kv =
+  let unset_kv _prop_kv _el =
+    ()
+    (* Unsetting a property does not always mean something... For instance, the
+       [checked] property of a checkbox can only be set to a boolean, and not be
+       "unset".
+       This is also why Brr does not have a [El.unset_prop].
+    *)
+  in
+  let set_kv ?old:_ (k,v) el =
+    Jv.set' (El.to_jv el) k v
+  in
+  let dummy_kv = (Jstr.empty, Jv.undefined) in
+  { unset_kv; set_kv; dummy_kv }
+
 let attach_kv {set_kv; unset_kv; dummy_kv} el attribs =
   let set_lwd_at () =
     let prev = ref dummy_kv in
@@ -265,6 +280,8 @@ let attach_attribs = attach_kv attr_kv
 
 let attach_styles = attach_kv style_kv
 
+let attach_props = attach_kv prop_kv
+
 let listen el (Handler {opts; type'; func}) =
   Ev.listen ?opts type' func (El.as_target el)
 
@@ -300,10 +317,11 @@ let attach_events el events =
     ) (pure_unit, Lwd.map2 ~f:(fun () () -> ()))
     events
 
-let v ?d ?(at=[]) ?(ev=[]) ?(st=[]) tag children =
+let v ?d ?(at=[]) ?(ev=[]) ?(st=[]) ?(pr=[]) tag children =
   let at, impure_at = prepare_col at in
   let ev, impure_ev = prepare_col ev in
   let st, impure_st = prepare_col st in
+  let pr, impure_pr = prepare_col pr in
   let children, impure_children = consume_children children in
   let el = El.v ?d ~at tag children in
   let result =
@@ -321,6 +339,8 @@ let v ?d ?(at=[]) ?(ev=[]) ?(st=[]) tag children =
   let result = attach_impure attach_events impure_ev result in
   let result = attach_impure attach_styles impure_st result in
   List.iter (fun kv -> style_kv.set_kv kv el) st;
+  let result = attach_impure attach_props impure_pr result in
+  List.iter (fun kv -> prop_kv.set_kv kv el) pr;
   result
 
 (** {1:els Element constructors} *)
@@ -330,6 +350,7 @@ type cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
+  ?pr:(Jstr.t * Jv.t) col ->
   t col ->
   t Lwd.t
 (** The type for element constructors. This is simply {!v} with a
@@ -340,13 +361,14 @@ type void_cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
+  ?pr:(Jstr.t * Jv.t) col ->
   unit ->
   t Lwd.t
 (** The type for void element constructors. This is simply {!v}
     with a pre-applied element name and without children. *)
 
-let cons name ?d ?at ?ev ?st cs = v ?d ?at ?ev ?st name cs
-let void_cons name ?d ?at ?ev ?st () = v ?d ?at ?ev ?st name []
+let cons name ?d ?at ?ev ?st ?pr cs = v ?d ?at ?ev ?st ?pr name cs
+let void_cons name ?d ?at ?ev ?st ?pr () = v ?d ?at ?ev ?st ?pr name []
 
 let a = cons Name.a
 let abbr = cons Name.abbr

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -27,12 +27,22 @@ val v :
   tag_name ->
   t col ->
   t Lwd.t
-(** [v ?d ?at name cs] is an element [name] with attribute [at]
-    (defaults to [[]]) and children [cs]. If [at] specifies an
-    attribute more thanonce, the last one takes over with the
-    exception of {!At.class'} whose occurences accumulate to define
-    the final value. [d] is the document on which the element is
-    defined it defaults {!Brr.G.document}. *)
+(** [v ?d ?at ?ev ?st?pr name cs] is an element [name] with:
+    - attribute [at] (defaults to [[]])
+    - event handlers [ev]
+    - inline styles [st]
+    - properties [pr]
+    - and children [cs].
+
+    All optional attributes default to [[]].
+
+    Note that attributes specified by multiple elements of [at] (even at
+    different sampling time) may result in undefined behavior. The only
+    exception is {!At.class'} whose occurrences accumulate to define the final
+    value.
+
+    [d] is the document on which the element is defined it defaults
+    {!Brr.G.document}. *)
 
 (** {1:els Element constructors} *)
 

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -21,6 +21,7 @@ val v :
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
+  ?pr:(Jstr.t * Jv.t) col ->
   tag_name ->
   t col ->
   t Lwd.t
@@ -38,6 +39,7 @@ type cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
+  ?pr:(Jstr.t * Jv.t) col ->
   t col ->
   t Lwd.t
 (** The type for element constructors. This is simply {!v} with a
@@ -48,6 +50,7 @@ type void_cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
+  ?pr:(Jstr.t * Jv.t) col ->
   unit ->
   t Lwd.t
 (** The type for void element constructors. This is simply {!v}

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -16,12 +16,14 @@ type 'a col = [
 type handler (* An event handler *)
 val handler : ?opts:Ev.listen_opts -> 'a Ev.type' -> ('a Ev.t -> unit) -> handler
 
+type prop = P : ('a El.Prop.t * 'a) -> prop
+
 val v :
   ?d:document ->
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
-  ?pr:(Jstr.t * Jv.t) col ->
+  ?pr:prop col ->
   tag_name ->
   t col ->
   t Lwd.t
@@ -39,7 +41,7 @@ type cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
-  ?pr:(Jstr.t * Jv.t) col ->
+  ?pr:prop col ->
   t col ->
   t Lwd.t
 (** The type for element constructors. This is simply {!v} with a
@@ -50,7 +52,7 @@ type void_cons =
   ?at:At.t col ->
   ?ev:handler col ->
   ?st:(El.Style.prop * Jstr.t) col ->
-  ?pr:(Jstr.t * Jv.t) col ->
+  ?pr:prop col ->
   unit ->
   t Lwd.t
 (** The type for void element constructors. This is simply {!v}

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -16,7 +16,14 @@ type 'a col = [
 type handler (* An event handler *)
 val handler : ?opts:Ev.listen_opts -> 'a Ev.type' -> ('a Ev.t -> unit) -> handler
 
-val v : ?d:document -> ?at:At.t col -> ?ev:handler col -> tag_name -> t col -> t Lwd.t
+val v :
+  ?d:document ->
+  ?at:At.t col ->
+  ?ev:handler col ->
+  ?st:(El.Style.prop * Jstr.t) col ->
+  tag_name ->
+  t col ->
+  t Lwd.t
 (** [v ?d ?at name cs] is an element [name] with attribute [at]
     (defaults to [[]]) and children [cs]. If [at] specifies an
     attribute more thanonce, the last one takes over with the
@@ -26,11 +33,23 @@ val v : ?d:document -> ?at:At.t col -> ?ev:handler col -> tag_name -> t col -> t
 
 (** {1:els Element constructors} *)
 
-type cons =  ?d:document -> ?at:At.t col -> ?ev:handler col -> t col -> t Lwd.t
+type cons =
+  ?d:document ->
+  ?at:At.t col ->
+  ?ev:handler col ->
+  ?st:(El.Style.prop * Jstr.t) col ->
+  t col ->
+  t Lwd.t
 (** The type for element constructors. This is simply {!v} with a
     pre-applied element name. *)
 
-type void_cons = ?d:document -> ?at:At.t col -> ?ev:handler col -> unit -> t Lwd.t
+type void_cons =
+  ?d:document ->
+  ?at:At.t col ->
+  ?ev:handler col ->
+  ?st:(El.Style.prop * Jstr.t) col ->
+  unit ->
+  t Lwd.t
 (** The type for void element constructors. This is simply {!v}
     with a pre-applied element name and without children. *)
 


### PR DESCRIPTION
Add reactive properties and styles.

Does not address #59, but reactive styles are unset when "not present anymore", while reactive props are not (as it would not make sense.

One of the commit is optional, it makes the API in some ways better (uses `Brr.El.Prop.t`) and worse (it requires a constructor to hide an existential type. `Brr.El.Prop.t` is restricted to basic types, but I did not find an example where an object type is needed). What do you think?

I also added two examples.

I'm not sure the `dummy_value` is a good OCaml pattern, but I kept it anyway! One step at a time!

It's probably good to review commit by commit. I tried to have a clean history. It starts with some refactoring to add abstractions to make adding styles and props easier. Then, styles, then props are added.

Also, notes that for the reason given in https://github.com/let-def/lwd/pull/54#issuecomment-3333189531, I kept the distinction between props and attributes.

Ping @voodoos!