### PR TITLE
Brr: Better ux for inserting reactive elements in the DOM

### DIFF
--- a/examples/cssclasstest-brr/index.html
+++ b/examples/cssclasstest-brr/index.html
@@ -27,6 +27,6 @@
 </style>
   </head>
   <body>
-    <div id="main"></div>
+    <div class="game-board"></div>
   </body>
 </html>

--- a/examples/cssclasstest-brr/index.html
+++ b/examples/cssclasstest-brr/index.html
@@ -3,14 +3,14 @@
 	  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <title>Minesweeper</title>
+    <title>Minesweeper embryo</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <script type="text/javascript" src="main.js"></script>
 <style>
 .square {
-  width: 1px;;
-  height: 1px;
-  padding: 1px;
+  width: 10px;;
+  height: 10px;
+  padding: 10px;
   border: solid 1px;
 }
 .square-on {
@@ -18,6 +18,11 @@
 }
 .square-off {
   background-color: blue;
+}
+.game-board {
+  width:800px;
+  display: flex;
+  flex-wrap: wrap;
 }
 </style>
   </head>

--- a/examples/cssclasstest-brr/main.ml
+++ b/examples/cssclasstest-brr/main.ml
@@ -40,7 +40,7 @@ let ui =
       Lwd_seq.monoid
       squares
   in
-  Elwd.div ~at:[ `P (At.class' (Jstr.v "game-board")) ] [
+  [
     `S (Lwd_seq.lift board)
   ]
 
@@ -51,8 +51,8 @@ let defer_after_dom_loading f =
 
 let () =
   defer_after_dom_loading @@ fun () ->
-  match El.find_first_by_selector (Jstr.v "#main") with
-  | None -> failwith "#main could not be found, check your html"
+  match El.find_first_by_selector (Jstr.v ".game-board") with
+  | None -> failwith ".game-board could not be found, check your html"
   | Some main ->
-    let _remove_token = Elwd.insert_sibling `Replace main ui in
+    let _remove_token = Elwd.set_children main ui in
     ()

--- a/examples/cssclasstest-brr/main.ml
+++ b/examples/cssclasstest-brr/main.ml
@@ -46,7 +46,9 @@ let ui =
 
 let defer_after_dom_loading f =
   let on_load _ = f () in
-  ignore (Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window));
+  let _listen_id =
+    Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window)
+  in
   ()
 
 let () =

--- a/examples/cssclasstest-brr/main.ml
+++ b/examples/cssclasstest-brr/main.ml
@@ -44,14 +44,15 @@ let ui =
     `S (Lwd_seq.lift board)
   ]
 
+let defer_after_dom_loading f =
+  let on_load _ = f () in
+  ignore (Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window));
+  ()
+
 let () =
-  let ui = Lwd.observe ui in
-  let on_invalidate _ =
-    ignore @@ G.request_animation_frame @@ fun _ ->
-      ignore @@ Lwd.quick_sample ui
-  in
-  let on_load _ =
-    El.append_children (Document.body G.document) [ Lwd.quick_sample ui ];
-    Lwd.set_on_invalidate ui on_invalidate
-  in
-  ignore @@ Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window)
+  defer_after_dom_loading @@ fun () ->
+  match El.find_first_by_selector (Jstr.v "#main") with
+  | None -> failwith "#main could not be found, check your html"
+  | Some main ->
+    let _remove_token = Elwd.insert_sibling `Replace main ui in
+    ()

--- a/examples/focustest-brr/main.ml
+++ b/examples/focustest-brr/main.ml
@@ -46,22 +46,15 @@ let ui =
     `S (Lwd_seq.map El.txt' values);
   ]
 
-let () =
-  let ui = Lwd.observe ui in
-  let on_invalidate _ =
-    Console.(log [str "on invalidate"]);
-    let _ : int =
-      G.request_animation_frame @@ fun _ ->
-      let _ui = Lwd.quick_sample ui in
-      (*El.set_children (Document.body G.document) [ui]*)
-      ()
-    in
-    ()
-  in
-  let on_load _ =
-    Console.(log [str "onload"]);
-    El.append_children (Document.body G.document) [Lwd.quick_sample ui];
-    Lwd.set_on_invalidate ui on_invalidate
-  in
+let defer_after_dom_loading f =
+  let on_load _ = f () in
   ignore (Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window));
   ()
+
+let () =
+  defer_after_dom_loading @@ fun () ->
+  match El.find_first_by_selector (Jstr.v "#main") with
+  | None -> failwith "#main could not be found, check your html"
+  | Some main ->
+    let _remove_token = Elwd.insert_sibling `Replace main ui in
+    ()

--- a/examples/focustest-brr/main.ml
+++ b/examples/focustest-brr/main.ml
@@ -48,7 +48,9 @@ let ui =
 
 let defer_after_dom_loading f =
   let on_load _ = f () in
-  ignore (Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window));
+  let _listen_id =
+    Ev.listen Ev.dom_content_loaded on_load (Window.as_target G.window)
+  in
   ()
 
 let () =

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -410,7 +410,7 @@ let var = cons Name.var
 let video = cons Name.video
 let wbr = void_cons Name.wbr
 
-type token = t Lwd.root
+type root = t Lwd.root
 
 let insert_sibling where anchor reactive =
   let root = Lwd.observe reactive in
@@ -452,7 +452,7 @@ let set_children el children =
   Lwd.set_on_invalidate root on_invalidate;
   root
 
-let remove_sibling root =
+let release root =
   let element = Lwd.quick_sample root in
   El.remove element;
   Lwd.quick_release root

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -431,6 +431,27 @@ let insert_sibling where anchor reactive =
   Lwd.set_on_invalidate root on_invalidate;
   root
 
+let set_children el children =
+  let reactive =
+    let children, impure_children = consume_children children in
+    match impure_children with
+    | None -> El.set_children el children; Lwd.pure el
+    | Some children ->
+      update_children el children
+  in
+  let root = Lwd.observe reactive in
+  let _el = Lwd.quick_sample root in
+  let on_invalidate _ =
+    let _ : int =
+      G.request_animation_frame @@ fun _ ->
+      let _el = Lwd.quick_sample root in
+      ()
+    in
+    ()
+  in
+  Lwd.set_on_invalidate root on_invalidate;
+  root
+
 let remove_sibling root =
   let element = Lwd.quick_sample root in
   El.remove element;

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -412,10 +412,10 @@ let wbr = void_cons Name.wbr
 
 type root = t Lwd.root
 
-let insert_sibling where anchor reactive =
+let insert first_insert anchor reactive =
   let root = Lwd.observe reactive in
   let last_element = ref (Lwd.quick_sample root) in
-  El.insert_siblings where anchor [ !last_element ];
+  first_insert anchor [!last_element];
   let on_invalidate _ =
     let _ : int =
       G.request_animation_frame @@ fun _ ->
@@ -430,6 +430,16 @@ let insert_sibling where anchor reactive =
   in
   Lwd.set_on_invalidate root on_invalidate;
   root
+
+let insert_sibling where anchor reactive =
+  let first_insert = El.insert_siblings where in
+  insert first_insert anchor reactive
+
+let append_child anchor reactive =
+  insert El.append_children anchor reactive
+
+let prepend_child anchor reactive =
+  insert El.prepend_children anchor reactive
 
 let set_children el children =
   let reactive =

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -409,3 +409,29 @@ let ul = cons Name.ul
 let var = cons Name.var
 let video = cons Name.video
 let wbr = void_cons Name.wbr
+
+type token = t Lwd.root
+
+let insert_sibling where anchor reactive =
+  let root = Lwd.observe reactive in
+  let last_element = ref (Lwd.quick_sample root) in
+  El.insert_siblings where anchor [ !last_element ];
+  let on_invalidate _ =
+    let _ : int =
+      G.request_animation_frame @@ fun _ ->
+      let new_element = Lwd.quick_sample root in
+      if !last_element = new_element then ()
+      else (
+        El.insert_siblings `Replace !last_element [ new_element ];
+        last_element := new_element
+      )
+    in
+    ()
+  in
+  Lwd.set_on_invalidate root on_invalidate;
+  root
+
+let remove_sibling root =
+  let element = Lwd.quick_sample root in
+  El.remove element;
+  Lwd.quick_release root

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -437,6 +437,10 @@ let set_children el children =
     match impure_children with
     | None -> El.set_children el children; Lwd.pure el
     | Some children ->
+      let root = Lwd.observe children in
+      let c = Lwd.quick_sample root in
+      El.set_children el (Lwd_seq.to_list c);
+      Lwd.quick_release root;
       update_children el children
   in
   let root = Lwd.observe reactive in

--- a/lib/brr-lwd/elwd.ml
+++ b/lib/brr-lwd/elwd.ml
@@ -456,7 +456,4 @@ let set_children el children =
   Lwd.set_on_invalidate root on_invalidate;
   root
 
-let release root =
-  let element = Lwd.quick_sample root in
-  El.remove element;
-  Lwd.quick_release root
+let release root = Lwd.quick_release root

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -39,6 +39,7 @@ val set_children : t -> t col -> root
     set is updated until the return value is passed to {!release}. *)
 
 val release : root -> unit
+(** Stop updating the reactive elements, leaving what is currently there. *)
 
 (** {1:els Element constructors} *)
 

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -16,6 +16,12 @@ type 'a col = [
 type handler (* An event handler *)
 val handler : ?opts:Ev.listen_opts -> 'a Ev.type' -> ('a Ev.t -> unit) -> handler
 
+type token
+
+val insert_sibling : [ `Before | `After | `Replace ] -> t -> t Lwd.t -> token
+
+val remove_sibling : token -> unit
+
 val v : ?d:document -> ?at:At.t col -> ?ev:handler col -> tag_name -> t col -> t Lwd.t
 (** [v ?d ?at name cs] is an element [name] with attribute [at]
     (defaults to [[]]) and children [cs]. If [at] specifies an

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -19,6 +19,7 @@ val handler : ?opts:Ev.listen_opts -> 'a Ev.type' -> ('a Ev.t -> unit) -> handle
 type token
 
 val insert_sibling : [ `Before | `After | `Replace ] -> t -> t Lwd.t -> token
+val set_children : t -> t col -> token
 
 val remove_sibling : token -> unit
 

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -16,13 +16,6 @@ type 'a col = [
 type handler (* An event handler *)
 val handler : ?opts:Ev.listen_opts -> 'a Ev.type' -> ('a Ev.t -> unit) -> handler
 
-type token
-
-val insert_sibling : [ `Before | `After | `Replace ] -> t -> t Lwd.t -> token
-val set_children : t -> t col -> token
-
-val remove_sibling : token -> unit
-
 val v : ?d:document -> ?at:At.t col -> ?ev:handler col -> tag_name -> t col -> t Lwd.t
 (** [v ?d ?at name cs] is an element [name] with attribute [at]
     (defaults to [[]]) and children [cs]. If [at] specifies an
@@ -30,6 +23,22 @@ val v : ?d:document -> ?at:At.t col -> ?ev:handler col -> tag_name -> t col -> t
     exception of {!At.class'} whose occurences accumulate to define
     the final value. [d] is the document on which the element is
     defined it defaults {!Brr.G.document}. *)
+
+
+(** {1 Inserting reactive elements in the DOM}  *)
+
+type root
+
+val insert_sibling : [ `Before | `After | `Replace ] -> t -> t Lwd.t -> root
+(** Inserts a reactive element in the DOM, right before/after/instead of the
+    given element. The element is updated until the return value is passed to
+    {!release}. *)
+
+val set_children : t -> t col -> root
+(** Sets a set of reactive elements as the children of the given element. The
+    set is updated until the return value is passed to {!release}. *)
+
+val release : root -> unit
 
 (** {1:els Element constructors} *)
 

--- a/lib/brr-lwd/elwd.mli
+++ b/lib/brr-lwd/elwd.mli
@@ -38,6 +38,16 @@ val set_children : t -> t col -> root
 (** Sets a set of reactive elements as the children of the given element. The
     set is updated until the return value is passed to {!release}. *)
 
+val append_child : t -> t Lwd.t -> root
+(** Inserts a reactive element in the DOM, as last child of the given
+    element. The element is updated until the return value is passed to
+    {!release}. *)
+
+val prepend_child : t -> t Lwd.t -> root
+(** Inserts a reactive element in the DOM, as first child of the given
+    element. The element is updated until the return value is passed to
+    {!release}. *)
+
 val release : root -> unit
 (** Stop updating the reactive elements, leaving what is currently there. *)
 


### PR DESCRIPTION
Yo! I _finally_ worked on this.

The way elements are inserted in the DOM in the brr-lwd examples is not ideal. It requires you to understand more of `Lwd`'s API than necessary, as well as `request_animation_frame`. Moreover it would not work as is for actually reactive elements (only for reactive children, which is the case in the examples).

So this PR introduces two ways to insert reactive elements in the DOM directly into the `brr-lwd` API. The examples are updated to use the two ways. EDIT: based on what I use on slipshow, I added `append_child` and `prepend_child`.

The API mimicks two standard way of inserting nodes in the DOM, [`insert_siblings`](https://ocaml.org/p/brr/0.0.8/doc/brr/Brr/El/index.html#val-insert_siblings) and [`set_children`](https://ocaml.org/p/brr/0.0.8/doc/brr/Brr/El/index.html#val-set_children), but with reactive siblings/children.

The main difference is that `insert_siblings` is `insert_sibling`: not plural, it takes a single element instead of a `t col`.
It is not really possible to have an ``insert_siblings `Replace el seq``, as if we replace `el` by a reactive sequence that is first empty (so we just remove `el`) and then non-empty, we lost our anchor to know where to add the new elements.

We could still add the following API:
```ocaml
val insert_siblings : [ `Before | `After ] -> t -> t col -> root
```
and I suggest to do so but in another PR, as it requires to refactor `update_children` quite a bit.
